### PR TITLE
Add email_inbox debug table for incoming email observability

### DIFF
--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -283,6 +283,34 @@ const MIGRATIONS: { version: number; sql: string }[] = [
       CREATE INDEX IF NOT EXISTS idx_audit_resource         ON audit_log(resource_type, resource_id);
     `,
 	},
+	{
+		// Email inbox log — tracks every inbound email for observability
+		version: 17,
+		sql: `
+      CREATE TABLE IF NOT EXISTS email_inbox (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        received_at INTEGER NOT NULL DEFAULT (unixepoch()),
+        sender TEXT NOT NULL,
+        recipient TEXT NOT NULL,
+        subject TEXT,
+        message_type TEXT,
+        status TEXT NOT NULL DEFAULT 'received',
+        rejection_reason TEXT,
+        policy_domain TEXT,
+        domain_id INTEGER,
+        report_id INTEGER,
+        raw_size_bytes INTEGER,
+        created_at INTEGER NOT NULL DEFAULT (unixepoch())
+      );
+      CREATE INDEX IF NOT EXISTS idx_inbox_received ON email_inbox(received_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_inbox_status ON email_inbox(status);
+    `,
+	},
+	{
+		// Store decompressed XML on email_inbox — preserves report data even for rejected emails
+		version: 18,
+		sql: `ALTER TABLE email_inbox ADD COLUMN raw_xml TEXT;`,
+	},
 ];
 
 let migrated = false;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -701,6 +701,64 @@ export function insertReportRecords(db: D1Database, records: Omit<ReportRecord, 
   ));
 }
 
+// ── Email Inbox Log ───────────────────────────────────────────
+
+export function insertEmailInbox(db: D1Database, r: {
+  sender: string;
+  recipient: string;
+  subject: string | null;
+  message_type: string | null;
+  status: string;
+  rejection_reason?: string | null;
+  policy_domain?: string | null;
+  domain_id?: number | null;
+  report_id?: number | null;
+  raw_size_bytes?: number | null;
+}) {
+  return db.prepare(`
+    INSERT INTO email_inbox
+      (sender, recipient, subject, message_type, status,
+       rejection_reason, policy_domain, domain_id, report_id, raw_size_bytes)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).bind(
+    r.sender, r.recipient, r.subject, r.message_type, r.status,
+    r.rejection_reason ?? null, r.policy_domain ?? null,
+    r.domain_id ?? null, r.report_id ?? null, r.raw_size_bytes ?? null,
+  ).run();
+}
+
+export function updateEmailInboxStatus(db: D1Database, id: number, status: string, extra?: {
+  rejection_reason?: string;
+  policy_domain?: string;
+  domain_id?: number;
+  report_id?: number;
+  raw_xml?: string;
+  raw_size_bytes?: number;
+}) {
+  const sets = ['status = ?'];
+  const vals: unknown[] = [status];
+  if (extra?.rejection_reason !== undefined) { sets.push('rejection_reason = ?'); vals.push(extra.rejection_reason); }
+  if (extra?.policy_domain !== undefined) { sets.push('policy_domain = ?'); vals.push(extra.policy_domain); }
+  if (extra?.domain_id !== undefined) { sets.push('domain_id = ?'); vals.push(extra.domain_id); }
+  if (extra?.report_id !== undefined) { sets.push('report_id = ?'); vals.push(extra.report_id); }
+  if (extra?.raw_xml !== undefined) { sets.push('raw_xml = ?'); vals.push(extra.raw_xml); }
+  if (extra?.raw_size_bytes !== undefined) { sets.push('raw_size_bytes = ?'); vals.push(extra.raw_size_bytes); }
+  vals.push(id);
+  return db.prepare(`UPDATE email_inbox SET ${sets.join(', ')} WHERE id = ?`).bind(...vals).run();
+}
+
+export function getRecentInboxEntries(db: D1Database, limit = 50, status?: string) {
+  if (status) {
+    return db.prepare(`SELECT * FROM email_inbox WHERE status = ? ORDER BY received_at DESC LIMIT ?`).bind(status, limit).all();
+  }
+  return db.prepare(`SELECT * FROM email_inbox ORDER BY received_at DESC LIMIT ?`).bind(limit).all();
+}
+
+export function cleanupOldInboxEntries(db: D1Database, olderThanDays = 7) {
+  const cutoff = Math.floor(Date.now() / 1000) - olderThanDays * 86400;
+  return db.prepare(`DELETE FROM email_inbox WHERE received_at < ?`).bind(cutoff).run();
+}
+
 // ── Telemetry heartbeat ───────────────────────────────────────
 
 export interface HeartbeatStats {

--- a/src/email/dmarc-report.ts
+++ b/src/email/dmarc-report.ts
@@ -9,12 +9,24 @@ import { Env } from '../index';
 import { extractAttachmentBytes, MimeExtractError } from './mime-extract';
 import { resolveDomain } from './resolve-domain';
 import { parseDmarcEmail, ParseEmailError } from '../dmarc/parse-email';
+import { extractReport } from '../dmarc/extract-report';
 import { storeReport } from '../dmarc/store-report';
+
+export interface DmarcReportResult {
+  failure_count: number;
+  status: 'processed' | 'rejected' | 'failed';
+  rejection_reason?: string;
+  policy_domain?: string;
+  domain_id?: number;
+  report_id?: number;
+  raw_size_bytes?: number;
+  raw_xml?: string;
+}
 
 export async function handleDmarcReport(
   message: ForwardableEmailMessage,
   env: Env,
-): Promise<{ failure_count: number }> {
+): Promise<DmarcReportResult> {
   // 1. Extract attachment bytes from raw MIME stream
   let bytes: Uint8Array;
   try {
@@ -25,40 +37,41 @@ export async function handleDmarcReport(
       : 'Unexpected error reading email';
     console.error('dmarc-report: mime extraction failed', err);
     message.setReject(reason);
-    return { failure_count: 0 };
+    return { failure_count: 0, status: 'rejected', rejection_reason: reason };
   }
 
+  const rawSizeBytes = bytes.byteLength;
+
   // 2. Parse the DMARC XML — needed to determine which domain this report is for
+  // Also extract decompressed XML for storage (works for gz/zip/plain XML)
   let report;
-  let rawXml: string | null = null;
+  let rawXml: string | undefined;
   try {
     report = await parseDmarcEmail(bytes, false, env.DB);
-
-    // Best-effort: store raw XML for plain XML attachments (gz/zip → null)
     try {
-      const decoded = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
-      if (decoded.trimStart().startsWith('<?xml') || decoded.trimStart().startsWith('<feed')) {
-        rawXml = decoded;
-      }
+      rawXml = extractReport(bytes);
     } catch {
-      // Binary attachment — rawXml stays null
+      // extractReport failed but parse succeeded — rawXml stays undefined
     }
   } catch (err) {
+    // Best-effort: try to get the XML even on parse failure
+    try { rawXml = extractReport(bytes); } catch {}
     const reason = err instanceof ParseEmailError
       ? `Invalid DMARC report: ${err.message}`
       : 'Unexpected error parsing DMARC report';
     console.error('dmarc-report: parse failed', err);
     message.setReject(reason);
-    return { failure_count: 0 };
+    return { failure_count: 0, status: 'rejected', rejection_reason: reason, raw_size_bytes: rawSizeBytes, raw_xml: rawXml };
   }
 
   // 3. Resolve domain from the policy_domain in the report
   const policyDomain = report.policy_published.domain;
   const domain = await resolveDomain(env.DB, policyDomain);
   if (!domain) {
+    const reason = `Unknown domain ${policyDomain} — not a registered InboxAngel inbox`;
     console.warn('dmarc-report: no domain found for policy_domain', policyDomain);
-    message.setReject(`Unknown domain ${policyDomain} — not a registered InboxAngel inbox`);
-    return { failure_count: 0 };
+    message.setReject(reason);
+    return { failure_count: 0, status: 'rejected', rejection_reason: reason, policy_domain: policyDomain, raw_size_bytes: rawSizeBytes, raw_xml: rawXml };
   }
 
   const failureCount = report.records.reduce((sum, r) => sum + (r.count ?? 0) * (r.policy_evaluated?.dkim === 'fail' || r.policy_evaluated?.spf === 'fail' ? 1 : 0), 0);
@@ -77,10 +90,26 @@ export async function handleDmarcReport(
         `for ${domain.domain} — skipped`
       );
     }
+    return {
+      failure_count: failureCount,
+      status: 'processed',
+      policy_domain: policyDomain,
+      domain_id: domain.id,
+      report_id: result.reportId,
+      raw_size_bytes: rawSizeBytes,
+      raw_xml: rawXml,
+    };
   } catch (err) {
     // Log but don't reject — email was valid, just a storage failure
     console.error('dmarc-report: D1 storage failed for', domain.domain, err);
+    return {
+      failure_count: failureCount,
+      status: 'failed',
+      rejection_reason: err instanceof Error ? err.message : 'D1 storage failed',
+      policy_domain: policyDomain,
+      domain_id: domain.id,
+      raw_size_bytes: rawSizeBytes,
+      raw_xml: rawXml,
+    };
   }
-
-  return { failure_count: failureCount };
 }

--- a/src/email/handler.ts
+++ b/src/email/handler.ts
@@ -3,6 +3,7 @@ import { handleFreeCheck } from './free-check';
 import { handleDmarcReport } from './dmarc-report';
 import { handleTlsRptReport } from './tls-rpt';
 import { track } from '../telemetry';
+import { insertEmailInbox, updateEmailInboxStatus, cleanupOldInboxEntries } from '../db/queries';
 
 // Routes inbound email by recipient address local part:
 //   rua@reports.yourdomain.com      → DMARC RUA aggregate report (routed by XML content)
@@ -14,16 +15,68 @@ export async function handleEmail(
   ctx: ExecutionContext
 ): Promise<void> {
   const to = message.to.toLowerCase();
+  const from = message.from.toLowerCase();
+  const subject = message.headers.get('subject') ?? null;
   const localPart = to.split('@')[0];
 
-  if (localPart === 'rua') {
-    const { failure_count } = await handleDmarcReport(message, env);
-    track(env, { event: 'report.received', failure_count }); // fire-and-forget
-  } else if (localPart === 'tls-rpt') {
-    const { failure_count } = await handleTlsRptReport(message, env);
-    track(env, { event: 'tls-rpt.received', failure_count }); // fire-and-forget
-  } else {
-    const { result } = await handleFreeCheck(message, env, localPart);
-    track(env, { event: 'check.received', result }); // fire-and-forget
+  const messageType = localPart === 'rua' ? 'dmarc-rua'
+    : localPart === 'tls-rpt' ? 'tls-rpt'
+    : 'free-check';
+
+  // Log to email_inbox — best effort, don't block on failure
+  let inboxId: number | null = null;
+  if (env.DB) {
+    try {
+      const result = await insertEmailInbox(env.DB, {
+        sender: from,
+        recipient: to,
+        subject,
+        message_type: messageType,
+        status: 'received',
+      });
+      inboxId = result.meta?.last_row_id ?? null;
+    } catch (e) {
+      console.warn('[inbox] failed to insert email_inbox row:', e);
+    }
+  }
+
+  try {
+    if (localPart === 'rua') {
+      const dmarcResult = await handleDmarcReport(message, env);
+      track(env, { event: 'report.received', failure_count: dmarcResult.failure_count });
+      if (inboxId && env.DB) {
+        updateEmailInboxStatus(env.DB, inboxId, dmarcResult.status, {
+          policy_domain: dmarcResult.policy_domain,
+          domain_id: dmarcResult.domain_id,
+          report_id: dmarcResult.report_id,
+          rejection_reason: dmarcResult.rejection_reason,
+          raw_xml: dmarcResult.raw_xml,
+          raw_size_bytes: dmarcResult.raw_size_bytes,
+        }).catch(() => {});
+      }
+    } else if (localPart === 'tls-rpt') {
+      const { failure_count } = await handleTlsRptReport(message, env);
+      track(env, { event: 'tls-rpt.received', failure_count });
+      if (inboxId && env.DB) {
+        updateEmailInboxStatus(env.DB, inboxId, 'processed').catch(() => {});
+      }
+    } else {
+      const { result } = await handleFreeCheck(message, env, localPart);
+      track(env, { event: 'check.received', result });
+      if (inboxId && env.DB) {
+        updateEmailInboxStatus(env.DB, inboxId, 'processed').catch(() => {});
+      }
+    }
+  } catch (e) {
+    if (inboxId && env.DB) {
+      const reason = e instanceof Error ? e.message : String(e);
+      updateEmailInboxStatus(env.DB, inboxId, 'failed', { rejection_reason: reason }).catch(() => {});
+    }
+    throw e;
+  }
+
+  // Opportunistic cleanup of old inbox entries (>7 days)
+  if (env.DB) {
+    ctx.waitUntil(cleanupOldInboxEntries(env.DB, 7).catch(() => {}));
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { handleEmail } from './email/handler';
 import { handleApi } from './api/router';
-import { getActiveSubscriptions, updateSubscriptionBaseline, getAllEnabledSpfFlattenConfigs, updateSpfFlattenResult, updateSpfFlattenError, getDomainById, getAllDomains, updateDomainSpfLookupCount, getAllEnabledMtaStsConfigs, getMtaStsConfigByDomain, updateMtaStsMxHosts, updateMtaStsError, getHeartbeatStats } from './db/queries';
+import { getActiveSubscriptions, updateSubscriptionBaseline, getAllEnabledSpfFlattenConfigs, updateSpfFlattenResult, updateSpfFlattenError, getDomainById, getAllDomains, updateDomainSpfLookupCount, getAllEnabledMtaStsConfigs, getMtaStsConfigByDomain, updateMtaStsMxHosts, updateMtaStsError, getHeartbeatStats, cleanupOldInboxEntries } from './db/queries';
 import { checkSubscription } from './monitor/check';
 import { sendChangeNotification } from './monitor/notify';
 import { sendWeeklyDigests } from './digest/weekly';
@@ -119,6 +119,9 @@ export default {
     }
 
     // Daily monitor check — every day 8am UTC (default / catch-all)
+    // Cleanup old email_inbox entries (>7 days)
+    cleanupOldInboxEntries(env.DB, 7).catch(e => console.warn('[cron] inbox cleanup failed:', e));
+
     // Also refresh SPF lookup counts for all domains
     const { results: allDomains } = await getAllDomains(env.DB);
     for (const d of allDomains) {

--- a/test/email/dmarc-report.test.ts
+++ b/test/email/dmarc-report.test.ts
@@ -30,11 +30,19 @@ vi.mock('../../src/dmarc/store-report', () => ({
   storeReport: vi.fn(),
 }));
 
+vi.mock('../../src/dmarc/extract-report', () => ({
+  extractReport: vi.fn(),
+  ParserError: class ParserError extends Error {
+    constructor(msg: string) { super(msg); this.name = 'ParserError'; }
+  },
+}));
+
 import { handleDmarcReport } from '../../src/email/dmarc-report';
 import * as mimeExtract from '../../src/email/mime-extract';
 import * as resolveDomainMod from '../../src/email/resolve-domain';
 import * as parseEmailMod from '../../src/dmarc/parse-email';
 import * as storeReportMod from '../../src/dmarc/store-report';
+import * as extractReportMod from '../../src/dmarc/extract-report';
 
 // ── Fixtures ──────────────────────────────────────────────────
 
@@ -107,6 +115,7 @@ beforeEach(() => {
   vi.mocked(resolveDomainMod.resolveDomain).mockResolvedValue(DOMAIN);
   vi.mocked(parseEmailMod.parseDmarcEmail).mockResolvedValue(REPORT);
   vi.mocked(storeReportMod.storeReport).mockResolvedValue({ stored: true, reportId: 42 });
+  vi.mocked(extractReportMod.extractReport).mockReturnValue('<xml>decompressed</xml>');
 });
 
 afterEach(() => vi.clearAllMocks());
@@ -157,7 +166,7 @@ describe('handleDmarcReport — happy path', () => {
     expect(message.setReject).not.toHaveBeenCalled();
   });
 
-  it('stores rawXml=null for binary (gz) attachments', async () => {
+  it('stores rawXml from extractReport for binary (gz) attachments', async () => {
     vi.mocked(mimeExtract.extractAttachmentBytes).mockResolvedValue(
       new Uint8Array([0x1f, 0x8b, 0x08])
     );
@@ -165,10 +174,10 @@ describe('handleDmarcReport — happy path', () => {
     await handleDmarcReport(makeMessage(), env);
 
     const [, , , rawXml] = vi.mocked(storeReportMod.storeReport).mock.calls[0];
-    expect(rawXml).toBeNull();
+    expect(rawXml).toBe('<xml>decompressed</xml>');
   });
 
-  it('stores rawXml string for plain XML attachments', async () => {
+  it('stores rawXml from extractReport for plain XML attachments', async () => {
     const xml = '<?xml version="1.0"?><feedback></feedback>';
     vi.mocked(mimeExtract.extractAttachmentBytes).mockResolvedValue(
       new TextEncoder().encode(xml)
@@ -177,7 +186,7 @@ describe('handleDmarcReport — happy path', () => {
     await handleDmarcReport(makeMessage(), env);
 
     const [, , , rawXml] = vi.mocked(storeReportMod.storeReport).mock.calls[0];
-    expect(rawXml).toBe(xml);
+    expect(rawXml).toBe('<xml>decompressed</xml>');
   });
 
   it('does not throw when storeReport returns stored=false (duplicate)', async () => {
@@ -271,5 +280,95 @@ describe('handleDmarcReport — error paths', () => {
     vi.mocked(storeReportMod.storeReport).mockRejectedValue(new Error('D1 unavailable'));
     const result = await handleDmarcReport(makeMessage(), makeEnv());
     expect(result).toHaveProperty('failure_count');
+  });
+});
+
+// ── DmarcReportResult fields — happy path ─────────────────────
+
+describe('handleDmarcReport — result fields (happy path)', () => {
+  it('returns status=processed on success', async () => {
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.status).toBe('processed');
+  });
+
+  it('returns policy_domain from parsed report', async () => {
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.policy_domain).toBe('acme.com');
+  });
+
+  it('returns domain_id and report_id on success', async () => {
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.domain_id).toBe(1);
+    expect(result.report_id).toBe(42);
+  });
+
+  it('returns raw_size_bytes from extracted bytes', async () => {
+    const bytes = new Uint8Array([0x1f, 0x8b]);
+    vi.mocked(mimeExtract.extractAttachmentBytes).mockResolvedValue(bytes);
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.raw_size_bytes).toBe(bytes.length);
+  });
+
+  it('returns raw_xml from extractReport', async () => {
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.raw_xml).toBe('<xml>decompressed</xml>');
+  });
+});
+
+// ── DmarcReportResult fields — error paths ────────────────────
+
+describe('handleDmarcReport — result fields (error paths)', () => {
+  it('returns status=rejected on MIME extraction failure', async () => {
+    vi.mocked(mimeExtract.extractAttachmentBytes).mockRejectedValue(
+      new mimeExtract.MimeExtractError('No DMARC attachment found')
+    );
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.status).toBe('rejected');
+    expect(result.rejection_reason).toContain('Could not extract attachment');
+  });
+
+  it('returns status=rejected on unknown domain', async () => {
+    vi.mocked(resolveDomainMod.resolveDomain).mockResolvedValue(null);
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.status).toBe('rejected');
+    expect(result.policy_domain).toBe('acme.com');
+  });
+
+  it('returns status=rejected on parse failure', async () => {
+    vi.mocked(parseEmailMod.parseDmarcEmail).mockRejectedValue(
+      new parseEmailMod.ParseEmailError('Invalid DMARC report XML')
+    );
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.status).toBe('rejected');
+    expect(result.rejection_reason).toContain('Invalid DMARC report');
+  });
+
+  it('returns status=failed on storage failure', async () => {
+    vi.mocked(storeReportMod.storeReport).mockRejectedValue(new Error('D1 unavailable'));
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.status).toBe('failed');
+    expect(result.rejection_reason).toBe('D1 unavailable');
+  });
+
+  it('returns raw_xml even on rejected emails (unknown domain)', async () => {
+    vi.mocked(resolveDomainMod.resolveDomain).mockResolvedValue(null);
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.raw_xml).toBe('<xml>decompressed</xml>');
+  });
+
+  it('returns raw_xml even on parse failure (best effort)', async () => {
+    vi.mocked(parseEmailMod.parseDmarcEmail).mockRejectedValue(
+      new parseEmailMod.ParseEmailError('bad xml')
+    );
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.raw_xml).toBe('<xml>decompressed</xml>');
+  });
+
+  it('returns no raw_xml on MIME extraction failure', async () => {
+    vi.mocked(mimeExtract.extractAttachmentBytes).mockRejectedValue(
+      new mimeExtract.MimeExtractError('No attachment')
+    );
+    const result = await handleDmarcReport(makeMessage(), makeEnv());
+    expect(result.raw_xml).toBeUndefined();
   });
 });

--- a/test/email/handler.test.ts
+++ b/test/email/handler.test.ts
@@ -1,0 +1,221 @@
+// Tests for email handler inbox logging behavior.
+// Mocks all sub-handlers and DB queries to verify the inbox log lifecycle.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Env } from '../../src/index';
+
+// ── Module mocks ──────────────────────────────────────────────
+
+vi.mock('../../src/email/dmarc-report', () => ({
+  handleDmarcReport: vi.fn(),
+}));
+
+vi.mock('../../src/email/tls-rpt', () => ({
+  handleTlsRptReport: vi.fn(),
+}));
+
+vi.mock('../../src/email/free-check', () => ({
+  handleFreeCheck: vi.fn(),
+}));
+
+vi.mock('../../src/telemetry', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('../../src/db/queries', () => ({
+  insertEmailInbox: vi.fn(),
+  updateEmailInboxStatus: vi.fn(),
+  cleanupOldInboxEntries: vi.fn(),
+}));
+
+import { handleEmail } from '../../src/email/handler';
+import * as dmarcReportMod from '../../src/email/dmarc-report';
+import * as tlsRptMod from '../../src/email/tls-rpt';
+import * as freeCheckMod from '../../src/email/free-check';
+import * as queriesMod from '../../src/db/queries';
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function makeMessage(to: string, from = 'sender@test.com', subject = 'Test'): ForwardableEmailMessage {
+  return {
+    from, to,
+    headers: new Headers([['subject', subject]]),
+    raw: new ReadableStream({ start(c) { c.close(); } }),
+    rawSize: 100,
+    reply: vi.fn(),
+    forward: vi.fn(),
+    setReject: vi.fn(),
+  } as unknown as ForwardableEmailMessage;
+}
+
+function makeEnv(): Env {
+  return { DB: {} as D1Database, ASSETS: {} as Fetcher } as Env;
+}
+
+function makeCtx(): ExecutionContext {
+  return { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as unknown as ExecutionContext;
+}
+
+// ── Setup ─────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.mocked(queriesMod.insertEmailInbox).mockResolvedValue({
+    meta: { last_row_id: 99, changes: 1, changed_db: true, duration: 0, rows_read: 0, rows_written: 1, size_after: 0 },
+    success: true,
+    results: [],
+  });
+  vi.mocked(queriesMod.updateEmailInboxStatus).mockResolvedValue({
+    meta: { last_row_id: 99, changes: 1, changed_db: true, duration: 0, rows_read: 0, rows_written: 1, size_after: 0 },
+    success: true,
+    results: [],
+  });
+  vi.mocked(queriesMod.cleanupOldInboxEntries).mockResolvedValue({
+    meta: { last_row_id: 0, changes: 0, changed_db: false, duration: 0, rows_read: 0, rows_written: 0, size_after: 0 },
+    success: true,
+    results: [],
+  });
+  vi.mocked(dmarcReportMod.handleDmarcReport).mockResolvedValue({
+    failure_count: 0,
+    status: 'processed',
+    policy_domain: 'acme.com',
+    domain_id: 1,
+    report_id: 42,
+    raw_size_bytes: 100,
+    raw_xml: '<xml>data</xml>',
+  });
+  vi.mocked(tlsRptMod.handleTlsRptReport).mockResolvedValue({ failure_count: 0 });
+  vi.mocked(freeCheckMod.handleFreeCheck).mockResolvedValue({ result: 'pass' } as any);
+});
+
+afterEach(() => vi.clearAllMocks());
+
+// ── Inbox logging ─────────────────────────────────────────────
+
+describe('handleEmail — inbox logging', () => {
+  it('inserts email_inbox row with received status on arrival', async () => {
+    const msg = makeMessage('rua@reports.example.com', 'sender@test.com', 'DMARC Report');
+    await handleEmail(msg, makeEnv(), makeCtx());
+
+    expect(queriesMod.insertEmailInbox).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sender: 'sender@test.com',
+        recipient: 'rua@reports.example.com',
+        subject: 'DMARC Report',
+        message_type: 'dmarc-rua',
+        status: 'received',
+      }),
+    );
+  });
+
+  it('detects message_type dmarc-rua for rua@ recipient', async () => {
+    await handleEmail(makeMessage('rua@reports.example.com'), makeEnv(), makeCtx());
+
+    const call = vi.mocked(queriesMod.insertEmailInbox).mock.calls[0];
+    expect(call[1].message_type).toBe('dmarc-rua');
+  });
+
+  it('detects message_type tls-rpt for tls-rpt@ recipient', async () => {
+    await handleEmail(makeMessage('tls-rpt@reports.example.com'), makeEnv(), makeCtx());
+
+    const call = vi.mocked(queriesMod.insertEmailInbox).mock.calls[0];
+    expect(call[1].message_type).toBe('tls-rpt');
+  });
+
+  it('detects message_type free-check for unknown local part', async () => {
+    await handleEmail(makeMessage('abc12345@reports.example.com'), makeEnv(), makeCtx());
+
+    const call = vi.mocked(queriesMod.insertEmailInbox).mock.calls[0];
+    expect(call[1].message_type).toBe('free-check');
+  });
+
+  it('updates inbox status to processed on DMARC success', async () => {
+    vi.mocked(dmarcReportMod.handleDmarcReport).mockResolvedValue({
+      failure_count: 0,
+      status: 'processed',
+      policy_domain: 'acme.com',
+      domain_id: 1,
+      report_id: 42,
+      raw_size_bytes: 200,
+      raw_xml: '<xml>report</xml>',
+    });
+
+    await handleEmail(makeMessage('rua@reports.example.com'), makeEnv(), makeCtx());
+
+    expect(queriesMod.updateEmailInboxStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      99,
+      'processed',
+      expect.objectContaining({
+        policy_domain: 'acme.com',
+        domain_id: 1,
+        report_id: 42,
+        raw_size_bytes: 200,
+        raw_xml: '<xml>report</xml>',
+      }),
+    );
+  });
+
+  it('updates inbox status to rejected with raw_xml on DMARC rejection', async () => {
+    vi.mocked(dmarcReportMod.handleDmarcReport).mockResolvedValue({
+      failure_count: 0,
+      status: 'rejected',
+      rejection_reason: 'Unknown domain foo.com',
+      raw_xml: '<xml>data</xml>',
+    });
+
+    await handleEmail(makeMessage('rua@reports.example.com'), makeEnv(), makeCtx());
+
+    expect(queriesMod.updateEmailInboxStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      99,
+      'rejected',
+      expect.objectContaining({
+        rejection_reason: 'Unknown domain foo.com',
+        raw_xml: '<xml>data</xml>',
+      }),
+    );
+  });
+
+  it('updates inbox status to failed on unexpected error', async () => {
+    vi.mocked(dmarcReportMod.handleDmarcReport).mockRejectedValue(new Error('boom'));
+
+    const msg = makeMessage('rua@reports.example.com');
+    await expect(handleEmail(msg, makeEnv(), makeCtx())).rejects.toThrow('boom');
+
+    expect(queriesMod.updateEmailInboxStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      99,
+      'failed',
+      expect.objectContaining({ rejection_reason: 'boom' }),
+    );
+  });
+
+  it('runs cleanup via ctx.waitUntil', async () => {
+    const ctx = makeCtx();
+    await handleEmail(makeMessage('rua@reports.example.com'), makeEnv(), ctx);
+
+    expect(ctx.waitUntil).toHaveBeenCalled();
+  });
+
+  it('does not crash if insertEmailInbox fails', async () => {
+    vi.mocked(queriesMod.insertEmailInbox).mockRejectedValue(new Error('D1 down'));
+
+    // Should complete without throwing
+    await handleEmail(makeMessage('rua@reports.example.com'), makeEnv(), makeCtx());
+
+    // Handler still called the sub-handler
+    expect(dmarcReportMod.handleDmarcReport).toHaveBeenCalled();
+  });
+
+  it('does not crash if DB is undefined', async () => {
+    const env = { DB: undefined, ASSETS: {} as Fetcher } as Env;
+
+    // Should complete without throwing
+    await handleEmail(makeMessage('rua@reports.example.com'), env, makeCtx());
+
+    // insertEmailInbox should NOT be called (no DB)
+    expect(queriesMod.insertEmailInbox).not.toHaveBeenCalled();
+    // Sub-handler still runs
+    expect(dmarcReportMod.handleDmarcReport).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #24

- **`email_inbox` table** (migration v17+v18) — logs every incoming email with sender, recipient, subject, message_type, status, rejection_reason, policy_domain, domain_id, report_id, raw_size_bytes, and **decompressed raw_xml**
- **`raw_xml` for all formats** — `extractReport()` decompresses gz/zip before storing in both `aggregate_reports` and `email_inbox`, so XML is preserved even for rejected/failed emails
- **Auto-cleanup** — deletes entries >7 days old via `ctx.waitUntil` on every email + daily 8am UTC cron
- **Structured `DmarcReportResult`** — dmarc-report handler returns status, raw_xml, raw_size_bytes, policy_domain, domain_id, report_id for inbox logging

## Test plan
- [x] Deployed and tested in prod with real emails (SMTP via Gmail)
- [x] Verified gz attachment → decompressed XML stored in `aggregate_reports.raw_xml` (15,305 bytes)
- [x] Verified rejected email (unknown domain) → XML stored in `email_inbox.raw_xml` (15,159 bytes)
- [x] Unit tests for `handleDmarcReport` result fields (12 new tests)
- [x] Unit tests for `handleEmail` inbox logging lifecycle (10 new tests)
- [ ] Verify cleanup cron deletes old entries after 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)