### PR TITLE
feat: HTML email reports with multipart/alternative (closes #39)

### DIFF
--- a/src/digest/weekly.ts
+++ b/src/digest/weekly.ts
@@ -8,6 +8,7 @@
 
 import { getWeeklyDomainStats, getTopFailingSources, DomainWeeklyStat, FailingSource } from '../db/queries';
 import { reportsDomain, fromEmail } from '../env-utils';
+import { buildWeeklyDigestHtml } from '../email/html-templates';
 import { version } from '../../package.json';
 
 const GH_RAW = 'https://raw.githubusercontent.com/Fellowship-dev/inbox-angel-worker/main/package.json';
@@ -121,6 +122,7 @@ async function sendDigest(
   email: string,
   subject: string,
   body: string,
+  html: string,
   env: DigestEnv,
 ): Promise<void> {
   if (!env.SEND_EMAIL) {
@@ -134,6 +136,7 @@ async function sendDigest(
       to: [email],
       subject,
       text: body,
+      html,
     });
   } catch (e) {
     console.error(`[digest] send failed for ${email}:`, e);
@@ -179,12 +182,22 @@ export async function sendWeeklyDigests(env: DigestEnv, now = Date.now()): Promi
     }
 
     const body = buildDigestBody(admin.name ?? 'there', stats, sourcesByDomain, weekLabel, ruaAddress, rd, latestVersion);
+    const html = buildWeeklyDigestHtml({
+      recipientName: admin.name ?? 'there',
+      stats,
+      sourcesByDomain,
+      weekLabel,
+      ruaAddress,
+      reportsDomain: rd,
+      latestVersion,
+      currentVersion: version,
+    });
     const hasIssues = stats.some(s => s.fail_messages > 0 || !s.dmarc_policy || s.dmarc_policy === 'none');
     const subject = hasIssues
       ? `⚠️ DMARC Weekly Digest — action needed`
       : `✅ DMARC Weekly Digest — all clear`;
 
-    await sendDigest(admin.email, subject, body, env);
+    await sendDigest(admin.email, subject, body, html, env);
     console.log(`[digest] sent to ${admin.email} (${stats.length} domain(s))`);
   } catch (e) {
     console.error('[digest] error:', e);

--- a/src/email/free-check.ts
+++ b/src/email/free-check.ts
@@ -7,6 +7,7 @@ import { Env } from '../index';
 import { extractAuthResults } from './parse-headers';
 import { checkDomain } from './dns-check';
 import { buildSummary, formatCheckReport } from './report-formatter';
+import { buildFreeCheckHtml } from './html-templates';
 import { insertCheckResult } from '../db/queries';
 import { fromEmail as derivedFromEmail } from '../env-utils';
 
@@ -15,16 +16,28 @@ function extractDomain(email: string): string {
   return at >= 0 ? email.slice(at + 1).toLowerCase() : email.toLowerCase();
 }
 
-function buildMimeReply(from: string, to: string, subject: string, body: string): ReadableStream {
+function buildMimeReply(from: string, to: string, subject: string, text: string, html: string): ReadableStream {
+  const boundary = `----=_Part_${Date.now()}_${Math.random().toString(36).slice(2)}`;
   const mimeContent = [
     'MIME-Version: 1.0',
     `From: ${from}`,
     `To: ${to}`,
     `Subject: ${subject}`,
+    `Content-Type: multipart/alternative; boundary="${boundary}"`,
+    '',
+    `--${boundary}`,
     'Content-Type: text/plain; charset=UTF-8',
     'Content-Transfer-Encoding: 7bit',
     '',
-    body,
+    text,
+    '',
+    `--${boundary}`,
+    'Content-Type: text/html; charset=UTF-8',
+    'Content-Transfer-Encoding: 7bit',
+    '',
+    html,
+    '',
+    `--${boundary}--`,
   ].join('\r\n');
 
   const bytes = new TextEncoder().encode(mimeContent);
@@ -56,13 +69,14 @@ export async function handleFreeCheck(
   // 4. Build structured summary and format plain-English report
   const summary = buildSummary(domain, auth, dns);
   const reportText = formatCheckReport(fromEmail, summary, auth, dns);
+  const reportHtml = buildFreeCheckHtml({ fromEmail, summary, auth, dns });
 
   // 5. Send reply
   const resolvedFrom = derivedFromEmail();
   if (!resolvedFrom) throw new Error('FROM_EMAIL not configured — complete the setup wizard first');
   const replyFrom = `InboxAngel <${resolvedFrom}>`;
   const subject = `Email security check — ${domain}`;
-  await message.reply(buildMimeReply(replyFrom, fromEmail, subject, reportText));
+  await message.reply(buildMimeReply(replyFrom, fromEmail, subject, reportText, reportHtml));
 
   // 6. Store result in D1 (best-effort — don't let DB failure break the email flow)
   try {

--- a/src/email/html-templates.ts
+++ b/src/email/html-templates.ts
@@ -1,0 +1,264 @@
+// Branded HTML email templates for all outbound report types.
+// All templates use inline CSS (no <style> blocks) for email-client compatibility.
+// Plain-text versions are generated separately and passed alongside HTML in multipart/alternative.
+
+import { DomainWeeklyStat, FailingSource } from '../db/queries';
+import { CheckSummary, OverallStatus } from './report-formatter';
+import { DomainChange } from '../monitor/check';
+import { DnsCheckResult } from './dns-check';
+import { AuthResultsHeader } from './parse-headers';
+import { brandLogoUrl, brandColor } from '../env-utils';
+
+// ── Primitives ────────────────────────────────────────────────
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function badge(label: string, color: string): string {
+  return `<span style="display:inline-block;padding:2px 8px;border-radius:3px;font-size:12px;font-weight:600;background:${color};color:#fff;">${esc(label)}</span>`;
+}
+
+function passBadge(pass: boolean): string {
+  return pass ? badge('PASS', '#16a34a') : badge('FAIL', '#dc2626');
+}
+
+function policyBadge(policy: string | null): string {
+  if (policy === 'reject')     return badge('reject', '#16a34a');
+  if (policy === 'quarantine') return badge('quarantine', '#d97706');
+  if (policy === 'none')       return badge('none', '#dc2626');
+  return badge('not set', '#dc2626');
+}
+
+function severityBadge(s: DomainChange['severity']): string {
+  if (s === 'improved') return badge('improved', '#16a34a');
+  if (s === 'degraded') return badge('degraded', '#dc2626');
+  return badge('changed', '#d97706');
+}
+
+function pct(n: number, total: number): string {
+  if (total === 0) return '0%';
+  return `${Math.round((n / total) * 100)}%`;
+}
+
+// ── Shared layout ─────────────────────────────────────────────
+
+function htmlLayout(title: string, bodyHtml: string): string {
+  const accent = esc(brandColor());
+  const logo = brandLogoUrl();
+  const logoHtml = logo
+    ? `<img src="${esc(logo)}" alt="InboxAngel" style="height:32px;vertical-align:middle;margin-right:8px;">`
+    : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${esc(title)}</title></head>
+<body style="margin:0;padding:0;background:#f3f4f6;font-family:Arial,sans-serif;font-size:14px;color:#111827;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f3f4f6;">
+<tr><td align="center" style="padding:24px 8px;">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:6px;overflow:hidden;max-width:600px;">
+  <tr><td style="background:${accent};padding:16px 24px;">
+    <span style="color:#fff;font-size:16px;font-weight:700;">${logoHtml}InboxAngel</span>
+  </td></tr>
+  <tr><td style="padding:24px;">
+    ${bodyHtml}
+  </td></tr>
+  <tr><td style="padding:12px 24px;background:#f9fafb;border-top:1px solid #e5e7eb;font-size:11px;color:#6b7280;text-align:center;">
+    InboxAngel — automated email security monitoring
+  </td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
+// ── Weekly digest ─────────────────────────────────────────────
+
+function domainSection(
+  stat: DomainWeeklyStat,
+  sources: FailingSource[],
+  ruaAddress: string,
+): string {
+  let html = `<h3 style="margin:20px 0 8px;font-size:15px;color:#111827;">${esc(stat.domain)}</h3>`;
+  html += `<p style="margin:0 0 8px;">DMARC policy: ${policyBadge(stat.dmarc_policy)}</p>`;
+
+  if (stat.total_messages === 0) {
+    html += `<p style="color:#6b7280;">No reports received this week. Verify <code>rua=mailto:${esc(ruaAddress)}</code> is in your DMARC record.</p>`;
+    return html;
+  }
+
+  html += `<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;margin-bottom:8px;">
+<tr style="background:#f9fafb;font-weight:600;"><td>Messages</td><td>Passed</td><td>Failed</td></tr>
+<tr><td>${stat.total_messages.toLocaleString()}</td>
+<td style="color:#16a34a;">${stat.pass_messages.toLocaleString()} (${pct(stat.pass_messages, stat.total_messages)})</td>
+<td style="color:#dc2626;">${stat.fail_messages.toLocaleString()} (${pct(stat.fail_messages, stat.total_messages)})</td></tr>
+</table>`;
+
+  if (sources.length > 0) {
+    html += `<p style="font-weight:600;margin:8px 0 4px;">Top failing sources:</p>
+<table cellpadding="4" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px;">
+<tr style="background:#f9fafb;font-weight:600;"><td>IP</td><td>From</td><td>Failures</td></tr>`;
+    for (const s of sources) {
+      html += `<tr><td>${esc(s.source_ip)}</td><td>${esc(s.header_from ?? '—')}</td><td>${s.total.toLocaleString()}</td></tr>`;
+    }
+    html += '</table>';
+  }
+
+  return html;
+}
+
+export interface WeeklyDigestHtmlParams {
+  recipientName: string;
+  stats: DomainWeeklyStat[];
+  sourcesByDomain: Map<number, FailingSource[]>;
+  weekLabel: string;
+  ruaAddress: string;
+  reportsDomain: string;
+  latestVersion: string | null;
+  currentVersion: string;
+}
+
+export function buildWeeklyDigestHtml(p: WeeklyDigestHtmlParams): string {
+  let body = `<h2 style="margin:0 0 16px;font-size:18px;">DMARC Weekly Digest</h2>
+<p style="margin:0 0 16px;">Hi ${esc(p.recipientName)}, here&rsquo;s your summary for the week of <strong>${esc(p.weekLabel)}</strong>.</p>
+<hr style="border:none;border-top:1px solid #e5e7eb;margin:16px 0;">`;
+
+  for (const stat of p.stats) {
+    body += domainSection(stat, p.sourcesByDomain.get(stat.domain_id) ?? [], p.ruaAddress);
+    body += '<hr style="border:none;border-top:1px solid #e5e7eb;margin:12px 0;">';
+  }
+
+  const weak = p.stats.filter(s => s.dmarc_policy === 'none' || !s.dmarc_policy);
+  if (weak.length > 0) {
+    body += `<p style="background:#fef9c3;border:1px solid #fde047;border-radius:4px;padding:12px;margin:16px 0;">
+<strong>${esc(weak.map(s => s.domain).join(', '))}</strong> ${weak.length === 1 ? 'is' : 'are'} not enforcing DMARC.
+<br>Want us to fix it? <a href="https://${esc(p.reportsDomain.replace(/^reports\./, ''))}">Sign up for InboxAngel</a>.
+</p>`;
+  }
+
+  if (p.latestVersion && p.latestVersion !== p.currentVersion) {
+    body += `<p style="font-size:12px;color:#6b7280;">Update available: v${esc(p.latestVersion)} (you're on v${esc(p.currentVersion)})</p>`;
+  }
+
+  return htmlLayout(`DMARC Weekly Digest — ${p.weekLabel}`, body);
+}
+
+// ── Free-check report ─────────────────────────────────────────
+
+const STATUS_COLOR: Record<OverallStatus, string> = {
+  protected: '#16a34a',
+  at_risk:   '#d97706',
+  exposed:   '#dc2626',
+};
+
+const STATUS_LABEL: Record<OverallStatus, string> = {
+  protected: 'Protected',
+  at_risk:   'At risk',
+  exposed:   'Exposed',
+};
+
+const STATUS_DESC: Record<OverallStatus, string> = {
+  protected: 'This email passed all security checks.',
+  at_risk:   'Your domain has partial protection — gaps remain.',
+  exposed:   'Anyone can send email pretending to be you.',
+};
+
+export interface FreeCheckHtmlParams {
+  fromEmail: string;
+  summary: CheckSummary;
+  auth: AuthResultsHeader | null;
+  dns: DnsCheckResult;
+}
+
+export function buildFreeCheckHtml(p: FreeCheckHtmlParams): string {
+  const { summary, auth, dns } = p;
+  const color = STATUS_COLOR[summary.status];
+
+  let body = `<div style="background:${color};color:#fff;border-radius:4px;padding:16px;margin-bottom:16px;">
+<span style="font-size:18px;font-weight:700;">${esc(STATUS_LABEL[summary.status])}</span>
+<span style="margin-left:12px;">${esc(STATUS_DESC[summary.status])}</span>
+</div>
+<p style="margin:0 0 12px;">Security check for <strong>${esc(summary.domain)}</strong></p>
+<table cellpadding="8" cellspacing="0" style="border-collapse:collapse;width:100%;margin-bottom:16px;">
+<tr style="background:#f9fafb;font-weight:600;"><td>Check</td><td>Result</td><td>Detail</td></tr>
+<tr style="border-top:1px solid #e5e7eb;">
+  <td><strong>SPF</strong></td>
+  <td>${passBadge(summary.spfPass)}</td>
+  <td style="font-size:13px;color:#374151;">${summary.spfPass ? 'Authorized sender' : 'Unauthorized or no record'}</td>
+</tr>
+<tr style="border-top:1px solid #e5e7eb;">
+  <td><strong>DKIM</strong></td>
+  <td>${passBadge(summary.dkimPass)}</td>
+  <td style="font-size:13px;color:#374151;">${summary.dkimPass ? 'Valid signature' : summary.dkimPresent ? 'Key found but email unsigned' : 'No signing key configured'}</td>
+</tr>
+<tr style="border-top:1px solid #e5e7eb;">
+  <td><strong>DMARC</strong></td>
+  <td>${passBadge(summary.dmarcPass)}</td>
+  <td style="font-size:13px;color:#374151;">Policy: ${policyBadge(summary.dmarcPolicy)}</td>
+</tr>
+</table>`;
+
+  // DNS records detail
+  body += `<h3 style="margin:16px 0 8px;font-size:13px;font-weight:600;color:#6b7280;text-transform:uppercase;">DNS Records</h3>
+<table cellpadding="4" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:12px;font-family:monospace;">`;
+  if (dns.spf) {
+    body += `<tr><td style="padding-right:12px;color:#6b7280;">SPF</td><td>${esc(dns.spf.raw)}</td></tr>`;
+  }
+  if (dns.dmarc) {
+    body += `<tr><td style="padding-right:12px;color:#6b7280;">DMARC</td><td>${esc(dns.dmarc.raw)}</td></tr>`;
+  }
+  if (dns.dkim) {
+    body += `<tr><td style="padding-right:12px;color:#6b7280;">DKIM</td><td>selector: ${esc(auth?.dkim?.selector ?? 'found')}</td></tr>`;
+  }
+  body += '</table>';
+
+  if (summary.status !== 'protected') {
+    body += `<p style="margin:16px 0 0;font-size:13px;color:#6b7280;">
+InboxAngel can walk you through each fix and monitor your domain 24/7.
+<a href="https://inboxangel.com" style="color:${esc(brandColor())};">Start free monitoring →</a>
+</p>`;
+  }
+
+  return htmlLayout(`Email Security Check — ${summary.domain}`, body);
+}
+
+// ── DNS change alert ──────────────────────────────────────────
+
+export interface DnsAlertHtmlParams {
+  domain: string;
+  changes: DomainChange[];
+  reportsDomain: string;
+}
+
+export function buildDnsAlertHtml(p: DnsAlertHtmlParams): string {
+  const hasDegraded = p.changes.some(c => c.severity === 'degraded');
+  const accent = brandColor();
+
+  let body = `<h2 style="margin:0 0 12px;font-size:18px;">Email security configuration changed</h2>
+<p style="margin:0 0 16px;">We detected changes to the email security configuration of <strong>${esc(p.domain)}</strong>.</p>
+<table cellpadding="8" cellspacing="0" style="border-collapse:collapse;width:100%;margin-bottom:16px;">
+<tr style="background:#f9fafb;font-weight:600;"><td>Field</td><td>Was</td><td>Now</td><td>Status</td></tr>`;
+
+  for (const c of p.changes) {
+    body += `<tr style="border-top:1px solid #e5e7eb;">
+<td><strong>${esc(c.field)}</strong></td>
+<td style="font-size:13px;color:#6b7280;">${esc(c.was || '(not set)')}</td>
+<td style="font-size:13px;">${esc(c.now || '(removed)')}</td>
+<td>${severityBadge(c.severity)}</td>
+</tr>`;
+  }
+
+  body += '</table>';
+
+  if (hasDegraded) {
+    body += `<p style="background:#fef2f2;border:1px solid #fecaca;border-radius:4px;padding:12px;margin:0 0 12px;">
+Some changes may leave your domain exposed to spoofing.
+<a href="https://${esc(p.reportsDomain.replace(/^reports\./, ''))}" style="color:${esc(accent)};">Fix it with InboxAngel →</a>
+</p>`;
+  } else {
+    body += `<p style="color:#6b7280;font-size:13px;">No action required — these look like improvements or routine updates.</p>`;
+  }
+
+  return htmlLayout(`${p.domain} email security updated`, body);
+}

--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -9,6 +9,8 @@ let _baseDomainCache: string | undefined;
 let _reportsDomainCache: string | undefined;
 let _fromEmailCache: string | undefined;
 let _workersSubdomainCache: string | undefined;
+let _brandLogoUrlCache: string | undefined;
+let _brandColorCache: string | undefined;
 
 /** Return the cached reports domain (e.g. "reports.yourdomain.com"). */
 export function reportsDomain(): string | undefined {
@@ -38,6 +40,16 @@ export function getBaseDomain(): string | undefined {
 /** Return the cached workers subdomain (e.g. "fellowshipdev"). */
 export function getWorkersSubdomain(): string | undefined {
   return _workersSubdomainCache;
+}
+
+/** Return the configured brand logo URL (optional, for HTML emails). */
+export function brandLogoUrl(): string | undefined {
+  return _brandLogoUrlCache;
+}
+
+/** Return the configured brand accent color (hex, e.g. "#4F46E5"). */
+export function brandColor(): string {
+  return _brandColorCache ?? '#4F46E5';
 }
 
 /**
@@ -105,6 +117,7 @@ export async function enrichEnv(env: Env, db?: D1Database): Promise<void> {
   if (effectiveDb && !_enrichedOnce) {
     const settings = await getSettings(effectiveDb, [
       'base_domain', 'zone_id', 'account_id', 'reports_domain', 'from_email', 'workers_subdomain',
+      'brand_logo_url', 'brand_color',
     ]);
 
     if (!_baseDomainCache) _baseDomainCache = settings.get('base_domain');
@@ -113,6 +126,8 @@ export async function enrichEnv(env: Env, db?: D1Database): Promise<void> {
     if (!_reportsDomainCache) _reportsDomainCache = settings.get('reports_domain');
     if (!_fromEmailCache) _fromEmailCache = settings.get('from_email');
     if (!_workersSubdomainCache) _workersSubdomainCache = settings.get('workers_subdomain');
+    if (!_brandLogoUrlCache) _brandLogoUrlCache = settings.get('brand_logo_url');
+    if (!_brandColorCache) _brandColorCache = settings.get('brand_color');
     _enrichedOnce = true;
   }
 
@@ -155,4 +170,6 @@ export function resetEnvCache(): void {
   _reportsDomainCache = undefined;
   _fromEmailCache = undefined;
   _workersSubdomainCache = undefined;
+  _brandLogoUrlCache = undefined;
+  _brandColorCache = undefined;
 }

--- a/src/monitor/notify.ts
+++ b/src/monitor/notify.ts
@@ -4,6 +4,7 @@
 
 import { DomainChange } from './check';
 import { reportsDomain, fromEmail } from '../env-utils';
+import { buildDnsAlertHtml } from '../email/html-templates';
 
 export interface NotifyEnv {
   SEND_EMAIL?: SendEmail;
@@ -57,6 +58,7 @@ export async function sendChangeNotification(
 
   const rd = reportsDomain()!;
   const body = buildEmailBody(domain, changes, rd);
+  const html = buildDnsAlertHtml({ domain, changes, reportsDomain: rd });
 
   if (!env.SEND_EMAIL) {
     console.log(`[notify] SEND_EMAIL binding not configured — would send to ${email}: ${subject}\n${body}`);
@@ -69,6 +71,7 @@ export async function sendChangeNotification(
       to: [email],
       subject,
       text: body,
+      html,
     });
   } catch (e) {
     console.error(`[notify] send failed for ${email}:`, e);

--- a/test/email/html-templates.test.ts
+++ b/test/email/html-templates.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock env-utils — module-level caches are empty in test
+vi.mock('../../src/env-utils', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    brandColor: vi.fn().mockReturnValue('#4F46E5'),
+    brandLogoUrl: vi.fn().mockReturnValue(undefined),
+  };
+});
+
+import {
+  buildWeeklyDigestHtml,
+  buildFreeCheckHtml,
+  buildDnsAlertHtml,
+} from '../../src/email/html-templates';
+import type { DomainWeeklyStat, FailingSource } from '../../src/db/queries';
+import type { CheckSummary } from '../../src/email/report-formatter';
+import type { DomainChange } from '../../src/monitor/check';
+import type { DnsCheckResult } from '../../src/email/dns-check';
+import type { AuthResultsHeader } from '../../src/email/parse-headers';
+
+// ── Fixtures ──────────────────────────────────────────────────
+
+const STAT_REJECT: DomainWeeklyStat = {
+  domain_id: 1, domain: 'acme.com', dmarc_policy: 'reject',
+  total_messages: 1000, pass_messages: 980, fail_messages: 20, report_count: 5,
+};
+
+const STAT_NONE: DomainWeeklyStat = {
+  domain_id: 2, domain: 'acme.net', dmarc_policy: 'none',
+  total_messages: 50, pass_messages: 30, fail_messages: 20, report_count: 1,
+};
+
+const STAT_NO_REPORTS: DomainWeeklyStat = {
+  domain_id: 3, domain: 'acme.org', dmarc_policy: null,
+  total_messages: 0, pass_messages: 0, fail_messages: 0, report_count: 0,
+};
+
+const SOURCE: FailingSource = { source_ip: '1.2.3.4', total: 15, header_from: 'mail.sender.com' };
+
+const DNS_FULL: DnsCheckResult = {
+  spf:  { raw: 'v=spf1 include:_spf.google.com ~all', verdict: 'softfail', lookup_count: 2 },
+  dkim: { present: true },
+  dmarc: { raw: 'v=DMARC1; p=reject', policy: 'reject', pct: 100 },
+};
+
+const AUTH_PASS: AuthResultsHeader = {
+  spf:   { result: 'pass',    domain: 'acme.com' },
+  dkim:  { result: 'pass',    domain: 'acme.com', selector: 'google' },
+  dmarc: { result: 'pass',    domain: 'acme.com', policy: 'reject', disposition: 'none' },
+  raw: '',
+};
+
+// ── Weekly digest ─────────────────────────────────────────────
+
+describe('buildWeeklyDigestHtml', () => {
+  function makeParams(overrides: Partial<Parameters<typeof buildWeeklyDigestHtml>[0]> = {}) {
+    const sourcesByDomain = new Map<number, FailingSource[]>();
+    sourcesByDomain.set(1, [SOURCE]);
+    return {
+      recipientName: 'Alice',
+      stats: [STAT_REJECT, STAT_NONE],
+      sourcesByDomain,
+      weekLabel: 'Mar 24, 2025',
+      ruaAddress: 'rua@reports.acme.com',
+      reportsDomain: 'reports.acme.com',
+      latestVersion: null,
+      currentVersion: '1.0.0',
+      ...overrides,
+    };
+  }
+
+  it('includes recipient name and week label', () => {
+    const html = buildWeeklyDigestHtml(makeParams());
+    expect(html).toContain('Alice');
+    expect(html).toContain('Mar 24, 2025');
+  });
+
+  it('renders reject badge for reject policy', () => {
+    const html = buildWeeklyDigestHtml(makeParams());
+    expect(html).toContain('reject');
+    expect(html).toContain('#16a34a'); // green color for reject badge
+  });
+
+  it('renders none badge for none policy', () => {
+    const html = buildWeeklyDigestHtml(makeParams());
+    expect(html).toContain('none');
+    expect(html).toContain('#dc2626'); // red color for none badge
+  });
+
+  it('shows pass/fail counts with percentages', () => {
+    const html = buildWeeklyDigestHtml(makeParams());
+    expect(html).toContain('1,000');
+    expect(html).toContain('980');
+    expect(html).toContain('98%');
+    expect(html).toContain('20');
+    expect(html).toContain('2%');
+  });
+
+  it('shows top failing sources table', () => {
+    const html = buildWeeklyDigestHtml(makeParams());
+    expect(html).toContain('1.2.3.4');
+    expect(html).toContain('mail.sender.com');
+  });
+
+  it('shows CTA for weak domains', () => {
+    const html = buildWeeklyDigestHtml(makeParams());
+    expect(html).toContain('acme.net');
+    expect(html).toContain('not enforcing DMARC');
+  });
+
+  it('shows no reports message when total_messages is 0', () => {
+    const html = buildWeeklyDigestHtml(makeParams({ stats: [STAT_NO_REPORTS] }));
+    expect(html).toContain('No reports received this week');
+    expect(html).toContain('rua@reports.acme.com');
+  });
+
+  it('shows update notice when latestVersion differs', () => {
+    const html = buildWeeklyDigestHtml(makeParams({ latestVersion: '2.0.0', currentVersion: '1.0.0' }));
+    expect(html).toContain('v2.0.0');
+    expect(html).toContain('v1.0.0');
+  });
+
+  it('omits update notice when on current version', () => {
+    const html = buildWeeklyDigestHtml(makeParams({ latestVersion: '1.0.0', currentVersion: '1.0.0' }));
+    expect(html).not.toContain('Update available');
+  });
+
+  it('is valid HTML with doctype', () => {
+    const html = buildWeeklyDigestHtml(makeParams());
+    expect(html).toMatch(/^<!DOCTYPE html>/);
+    expect(html).toContain('</html>');
+  });
+});
+
+// ── Free-check report ─────────────────────────────────────────
+
+describe('buildFreeCheckHtml', () => {
+  function makeSummary(status: CheckSummary['status'], overrides: Partial<CheckSummary> = {}): CheckSummary {
+    return {
+      status,
+      domain: 'acme.com',
+      spfPass: status === 'protected',
+      dkimPass: status === 'protected',
+      dmarcPass: status === 'protected',
+      dmarcPolicy: status === 'exposed' ? null : 'reject',
+      dkimPresent: true,
+      ...overrides,
+    };
+  }
+
+  it('shows green banner for protected status', () => {
+    const html = buildFreeCheckHtml({ fromEmail: 'user@acme.com', summary: makeSummary('protected'), auth: AUTH_PASS, dns: DNS_FULL });
+    expect(html).toContain('Protected');
+    expect(html).toContain('#16a34a');
+  });
+
+  it('shows orange banner for at_risk status', () => {
+    const html = buildFreeCheckHtml({ fromEmail: 'user@acme.com', summary: makeSummary('at_risk'), auth: AUTH_PASS, dns: DNS_FULL });
+    expect(html).toContain('At risk');
+    expect(html).toContain('#d97706');
+  });
+
+  it('shows red banner for exposed status', () => {
+    const html = buildFreeCheckHtml({ fromEmail: 'user@acme.com', summary: makeSummary('exposed'), auth: null, dns: DNS_FULL });
+    expect(html).toContain('Exposed');
+    expect(html).toContain('#dc2626');
+  });
+
+  it('shows PASS badges for all checks when protected', () => {
+    const html = buildFreeCheckHtml({ fromEmail: 'user@acme.com', summary: makeSummary('protected'), auth: AUTH_PASS, dns: DNS_FULL });
+    expect(html.match(/PASS/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('shows FAIL badges for failed checks', () => {
+    const html = buildFreeCheckHtml({ fromEmail: 'user@acme.com', summary: makeSummary('exposed'), auth: null, dns: DNS_FULL });
+    expect(html).toContain('FAIL');
+  });
+
+  it('shows SPF and DMARC DNS records', () => {
+    const html = buildFreeCheckHtml({ fromEmail: 'user@acme.com', summary: makeSummary('protected'), auth: AUTH_PASS, dns: DNS_FULL });
+    expect(html).toContain('v=spf1');
+    expect(html).toContain('v=DMARC1');
+  });
+
+  it('shows CTA for non-protected status', () => {
+    const html = buildFreeCheckHtml({ fromEmail: 'user@acme.com', summary: makeSummary('exposed'), auth: null, dns: DNS_FULL });
+    expect(html).toContain('inboxangel.com');
+  });
+
+  it('omits CTA for protected status', () => {
+    const html = buildFreeCheckHtml({ fromEmail: 'user@acme.com', summary: makeSummary('protected'), auth: AUTH_PASS, dns: DNS_FULL });
+    expect(html).not.toContain('Start free monitoring');
+  });
+
+  it('is valid HTML with doctype', () => {
+    const html = buildFreeCheckHtml({ fromEmail: 'user@acme.com', summary: makeSummary('protected'), auth: AUTH_PASS, dns: DNS_FULL });
+    expect(html).toMatch(/^<!DOCTYPE html>/);
+    expect(html).toContain('</html>');
+  });
+});
+
+// ── DNS change alert ──────────────────────────────────────────
+
+describe('buildDnsAlertHtml', () => {
+  const degraded: DomainChange = { field: 'DMARC policy', was: 'reject', now: 'none', severity: 'degraded' };
+  const improved: DomainChange = { field: 'DMARC policy', was: 'none', now: 'reject', severity: 'improved' };
+  const changed:  DomainChange = { field: 'SPF record', was: 'v=spf1 ~all', now: 'v=spf1 -all', severity: 'changed' };
+
+  it('shows domain name in heading', () => {
+    const html = buildDnsAlertHtml({ domain: 'acme.com', changes: [degraded], reportsDomain: 'reports.acme.com' });
+    expect(html).toContain('acme.com');
+  });
+
+  it('shows degraded badge in red', () => {
+    const html = buildDnsAlertHtml({ domain: 'acme.com', changes: [degraded], reportsDomain: 'reports.acme.com' });
+    expect(html).toContain('degraded');
+    expect(html).toContain('#dc2626');
+  });
+
+  it('shows improved badge in green', () => {
+    const html = buildDnsAlertHtml({ domain: 'acme.com', changes: [improved], reportsDomain: 'reports.acme.com' });
+    expect(html).toContain('improved');
+    expect(html).toContain('#16a34a');
+  });
+
+  it('shows changed badge in orange', () => {
+    const html = buildDnsAlertHtml({ domain: 'acme.com', changes: [changed], reportsDomain: 'reports.acme.com' });
+    expect(html).toContain('changed');
+    expect(html).toContain('#d97706');
+  });
+
+  it('shows old and new values in change table', () => {
+    const html = buildDnsAlertHtml({ domain: 'acme.com', changes: [degraded], reportsDomain: 'reports.acme.com' });
+    expect(html).toContain('reject');
+    expect(html).toContain('none');
+    expect(html).toContain('DMARC policy');
+  });
+
+  it('shows warning CTA when changes include degraded', () => {
+    const html = buildDnsAlertHtml({ domain: 'acme.com', changes: [degraded], reportsDomain: 'reports.acme.com' });
+    expect(html).toContain('exposed to spoofing');
+    expect(html).toContain('acme.com'); // strip reports. prefix
+  });
+
+  it('shows no-action message when no degraded changes', () => {
+    const html = buildDnsAlertHtml({ domain: 'acme.com', changes: [improved], reportsDomain: 'reports.acme.com' });
+    expect(html).toContain('No action required');
+  });
+
+  it('is valid HTML with doctype', () => {
+    const html = buildDnsAlertHtml({ domain: 'acme.com', changes: [degraded], reportsDomain: 'reports.acme.com' });
+    expect(html).toMatch(/^<!DOCTYPE html>/);
+    expect(html).toContain('</html>');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds branded HTML email templates for all three outbound report types: weekly digest, free-check report, and DNS change alerts
- All emails are now sent as `multipart/alternative` (HTML + plain-text fallback)
- Branding (logo URL, accent color) is configurable via the `settings` D1 table — no code changes needed for self-hosted deployments

## Changes

| File | Change |
|------|--------|
| `src/env-utils.ts` | Added `brandLogoUrl()` and `brandColor()` helpers (reads from D1 `settings`) |
| `src/email/html-templates.ts` | **New** — shared branded layout + `buildWeeklyDigestHtml()`, `buildFreeCheckHtml()`, `buildDnsAlertHtml()` |
| `src/digest/weekly.ts` | Wire `html:` field into `SEND_EMAIL.send()` alongside existing `text:` |
| `src/email/free-check.ts` | `buildMimeReply()` upgraded to `multipart/alternative` boundary encoding |
| `src/monitor/notify.ts` | Wire `html:` field into `SEND_EMAIL.send()` alongside existing `text:` |
| `test/email/html-templates.test.ts` | **New** — 27 unit tests covering all three HTML builders |

## Technical Approach

- Cloudflare `SendEmail` binding natively accepts `{ html, text }` — no MIME library needed for digest/alerts
- Free-check uses `message.reply()` with raw MIME string → upgraded to proper `multipart/alternative` boundary encoding
- Inline CSS throughout for Gmail/Outlook/Apple Mail compatibility
- Pass/fail badges use green/red/orange background colors with white text
- Plain-text bodies left unchanged as fallback (full content parity)

## Test Results

59 tests passing, 0 TypeScript errors.

Closes #39