### PR TITLE
feat: PDF summary report export for management (#43)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,6 +8,7 @@
       "name": "inbox-angel-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "jspdf": "^2.5.2",
         "preact": "^10.26.4"
       },
       "devDependencies": {
@@ -281,6 +282,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1293,6 +1303,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/babel-plugin-transform-hook-names": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-hook-names/-/babel-plugin-transform-hook-names-1.0.2.tgz",
@@ -1301,6 +1330,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@babel/core": "^7.12.10"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1357,6 +1396,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001777",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
@@ -1378,12 +1429,54 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -1476,6 +1569,13 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
+      "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/domutils": {
       "version": "3.2.2",
@@ -1589,6 +1689,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1624,6 +1730,20 @@
         "he": "bin/he"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1655,6 +1775,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/kolorist": {
@@ -1741,6 +1879,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1798,6 +1943,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -1895,6 +2067,36 @@
         "node": ">=16"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -1955,6 +2157,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "jspdf": "^2.5.2",
     "preact": "^10.26.4"
   },
   "devDependencies": {

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -36,6 +36,12 @@ export async function getDomains(): Promise<{ domains: import('./types').Domain[
   return res.json();
 }
 
+export async function getDomainCheckSummary(id: number): Promise<import('./types').DomainCheckSummary> {
+  const res = await apiFetch(`/api/domains/${id}/check-summary`);
+  if (!res.ok) await throwApiError(res);
+  return res.json();
+}
+
 export async function getDomainStats(id: number, days = 7): Promise<import('./types').DomainStats> {
   const res = await apiFetch(`/api/domains/${id}/stats?days=${days}`);
   if (!res.ok) await throwApiError(res);

--- a/dashboard/src/components/PdfReport.ts
+++ b/dashboard/src/components/PdfReport.ts
@@ -1,5 +1,6 @@
 import { jsPDF } from 'jspdf';
 import type { DomainCheckSummary, DailyStat } from '../types';
+import { getAllRecommendations, type Recommendation } from '../utils/pdfRecommendations';
 
 // ── Colours & layout constants ────────────────────────────────
 
@@ -161,6 +162,51 @@ export function buildPdfReport(data: PdfReportData): jsPDF {
     doc.text(mtaLabel, x + 1, y + 5.5);
 
     y += 8;
+  }
+
+  // ── Recommendations section ────────────────────────────────
+  const recs = getAllRecommendations(summaries);
+  if (recs.length > 0) {
+    y = addPageIfNeeded(doc, y, 20);
+    y += 8;
+
+    doc.setTextColor(...DARK_COLOR);
+    doc.setFontSize(13);
+    doc.setFont('helvetica', 'bold');
+    doc.text('Recommendations', MARGIN, y);
+    y += 6;
+
+    const SEVERITY_COLOR: Record<Recommendation['severity'], [number, number, number]> = {
+      critical: FAIL_COLOR,
+      warning:  WARN_COLOR,
+      info:     [59, 130, 246], // blue-500
+    };
+
+    for (const rec of recs) {
+      y = addPageIfNeeded(doc, y, 14);
+
+      const color = SEVERITY_COLOR[rec.severity];
+      // Severity badge
+      doc.setFillColor(...color);
+      doc.roundedRect(MARGIN, y, 18, 5, 1, 1, 'F');
+      doc.setTextColor(255, 255, 255);
+      doc.setFontSize(7);
+      doc.setFont('helvetica', 'bold');
+      doc.text(rec.severity.toUpperCase(), MARGIN + 1.5, y + 3.5);
+
+      // Domain label
+      doc.setTextColor(...MUTED_COLOR);
+      doc.setFontSize(7);
+      doc.setFont('helvetica', 'normal');
+      doc.text(rec.domain, MARGIN + 20, y + 3.5);
+
+      // Message (wrap to fit page width)
+      doc.setTextColor(...DARK_COLOR);
+      doc.setFontSize(8.5);
+      const lines = doc.splitTextToSize(rec.message, COL_W - 4) as string[];
+      doc.text(lines, MARGIN + 2, y + 9);
+      y += 8 + lines.length * 4.5;
+    }
   }
 
   return doc;

--- a/dashboard/src/components/PdfReport.ts
+++ b/dashboard/src/components/PdfReport.ts
@@ -209,6 +209,67 @@ export function buildPdfReport(data: PdfReportData): jsPDF {
     }
   }
 
+  // ── Trend section ──────────────────────────────────────────
+  const trends = data.trends;
+  if (trends && Object.keys(trends).length > 0) {
+    y = addPageIfNeeded(doc, y, 20);
+    y += 8;
+
+    doc.setTextColor(...DARK_COLOR);
+    doc.setFontSize(13);
+    doc.setFont('helvetica', 'bold');
+    doc.text('Weekly DMARC Pass Rate Trend', MARGIN, y);
+    y += 6;
+
+    for (const d of summaries) {
+      const stats = trends[d.domain_id];
+      if (!stats || stats.length === 0) continue;
+
+      // Aggregate into weeks (ISO week buckets by 7 days)
+      const weeks: { label: string; total: number; passed: number }[] = [];
+      const sorted = [...stats].sort((a, b) => a.day.localeCompare(b.day));
+      let bucket: { label: string; total: number; passed: number } | null = null;
+      for (const s of sorted) {
+        // New bucket every 7 days
+        if (!bucket || weeks.length === 0 || s.day > (bucket.label.split('→')[1]?.trim() ?? '')) {
+          const weekEnd = new Date(s.day);
+          weekEnd.setDate(weekEnd.getDate() + 6);
+          const label = `${s.day} → ${weekEnd.toISOString().slice(0, 10)}`;
+          bucket = { label, total: 0, passed: 0 };
+          weeks.push(bucket);
+        }
+        bucket.total += s.total;
+        bucket.passed += s.passed;
+      }
+
+      if (weeks.length === 0) continue;
+
+      y = addPageIfNeeded(doc, y, 8 + weeks.length * 6);
+
+      // Domain header
+      doc.setFontSize(9);
+      doc.setFont('helvetica', 'bold');
+      doc.setTextColor(...DARK_COLOR);
+      doc.text(d.domain, MARGIN, y);
+      y += 5;
+
+      // Week rows
+      for (const w of weeks) {
+        const rate = w.total > 0 ? Math.round((w.passed / w.total) * 100) : null;
+        const color: [number, number, number] = rate === null ? MUTED_COLOR : rate >= 95 ? PASS_COLOR : rate >= 70 ? WARN_COLOR : FAIL_COLOR;
+
+        doc.setFontSize(7.5);
+        doc.setFont('helvetica', 'normal');
+        doc.setTextColor(...MUTED_COLOR);
+        doc.text(w.label, MARGIN + 2, y);
+        doc.setTextColor(...color);
+        doc.text(rate !== null ? `${rate}% (${w.passed.toLocaleString()}/${w.total.toLocaleString()})` : 'No data', MARGIN + 80, y);
+        y += 5;
+      }
+      y += 3;
+    }
+  }
+
   return doc;
 }
 

--- a/dashboard/src/components/PdfReport.ts
+++ b/dashboard/src/components/PdfReport.ts
@@ -1,0 +1,172 @@
+import { jsPDF } from 'jspdf';
+import type { DomainCheckSummary, DailyStat } from '../types';
+
+// ── Colours & layout constants ────────────────────────────────
+
+const PASS_COLOR: [number, number, number] = [34, 197, 94];   // green-500
+const FAIL_COLOR: [number, number, number] = [239, 68, 68];   // red-500
+const WARN_COLOR: [number, number, number] = [234, 179, 8];   // yellow-500
+const DARK_COLOR: [number, number, number] = [30, 30, 46];    // near-black
+const MUTED_COLOR: [number, number, number] = [100, 100, 120];
+const PAGE_W = 210; // A4 mm
+const MARGIN = 14;
+const COL_W = PAGE_W - MARGIN * 2;
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function passRate(pass: number, total: number): string {
+  if (total === 0) return 'N/A';
+  return `${Math.round((pass / total) * 100)}%`;
+}
+
+function statusLabel(pass: number, total: number): { label: string; color: [number, number, number] } {
+  if (total === 0) return { label: 'Pending', color: MUTED_COLOR };
+  const rate = pass / total;
+  if (rate >= 0.95) return { label: 'Pass', color: PASS_COLOR };
+  if (rate >= 0.7)  return { label: 'Warning', color: WARN_COLOR };
+  return { label: 'Fail', color: FAIL_COLOR };
+}
+
+function dmarcPolicyLabel(policy: string | null): { label: string; color: [number, number, number] } {
+  if (policy === 'reject')     return { label: 'reject', color: PASS_COLOR };
+  if (policy === 'quarantine') return { label: 'quarantine', color: WARN_COLOR };
+  if (policy === 'none')       return { label: 'none (monitor only)', color: FAIL_COLOR };
+  return { label: 'Not configured', color: FAIL_COLOR };
+}
+
+function addPageIfNeeded(doc: jsPDF, y: number, needed = 20): number {
+  if (y + needed > 275) {
+    doc.addPage();
+    return 20;
+  }
+  return y;
+}
+
+// ── Main builder ──────────────────────────────────────────────
+
+export interface PdfReportData {
+  summaries: DomainCheckSummary[];
+  // trend: weekly stats per domain — added in T009/T010
+  trends?: Record<number, DailyStat[]>;
+}
+
+export function buildPdfReport(data: PdfReportData): jsPDF {
+  const { summaries } = data;
+  const doc = new jsPDF({ unit: 'mm', format: 'a4' });
+  const now = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+  // ── Cover ──────────────────────────────────────────────────
+  doc.setFillColor(...DARK_COLOR);
+  doc.rect(0, 0, PAGE_W, 50, 'F');
+
+  doc.setTextColor(255, 255, 255);
+  doc.setFontSize(20);
+  doc.setFont('helvetica', 'bold');
+  doc.text('Email Authentication Health Report', MARGIN, 22);
+
+  doc.setFontSize(10);
+  doc.setFont('helvetica', 'normal');
+  doc.text(`Generated ${now} · Last 30 days of data`, MARGIN, 32);
+  doc.text(`${summaries.length} domain${summaries.length !== 1 ? 's' : ''} monitored`, MARGIN, 40);
+
+  // ── Overall summary banner ─────────────────────────────────
+  let y = 60;
+  const totalMsgs = summaries.reduce((s, d) => s + d.total_messages, 0);
+  const passMsgs  = summaries.reduce((s, d) => s + d.pass_messages,  0);
+  const overallRate = totalMsgs > 0 ? Math.round((passMsgs / totalMsgs) * 100) : null;
+
+  doc.setTextColor(...DARK_COLOR);
+  doc.setFontSize(13);
+  doc.setFont('helvetica', 'bold');
+  doc.text('Overall DMARC Pass Rate', MARGIN, y);
+
+  doc.setFontSize(28);
+  const rateStr = overallRate !== null ? `${overallRate}%` : 'No data';
+  const rateColor = overallRate === null ? MUTED_COLOR : overallRate >= 95 ? PASS_COLOR : overallRate >= 70 ? WARN_COLOR : FAIL_COLOR;
+  doc.setTextColor(...rateColor);
+  doc.text(rateStr, MARGIN, y + 12);
+
+  doc.setFontSize(10);
+  doc.setTextColor(...MUTED_COLOR);
+  doc.text(`${passMsgs.toLocaleString()} of ${totalMsgs.toLocaleString()} messages passed`, MARGIN, y + 20);
+
+  y += 34;
+
+  // ── Per-domain table ──────────────────────────────────────
+  doc.setTextColor(...DARK_COLOR);
+  doc.setFontSize(13);
+  doc.setFont('helvetica', 'bold');
+  doc.text('Domain Status', MARGIN, y);
+  y += 6;
+
+  // Table header
+  const cols = [52, 28, 28, 28, 28, 28];
+  const headers = ['Domain', 'DMARC Policy', 'DMARC Rate', 'SPF Rate', 'DKIM Rate', 'MTA-STS'];
+  let x = MARGIN;
+  doc.setFillColor(240, 240, 248);
+  doc.rect(MARGIN, y, COL_W, 7, 'F');
+  doc.setFontSize(8);
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(...DARK_COLOR);
+  for (let i = 0; i < headers.length; i++) {
+    doc.text(headers[i], x + 1, y + 5);
+    x += cols[i];
+  }
+  y += 7;
+
+  // Table rows
+  doc.setFont('helvetica', 'normal');
+  for (const d of summaries) {
+    y = addPageIfNeeded(doc, y, 10);
+
+    const policy = dmarcPolicyLabel(d.dmarc_policy);
+    const dmarcStatus = statusLabel(d.pass_messages, d.total_messages);
+    const spfStatus   = statusLabel(d.spf_pass,       d.spf_total);
+    const dkimStatus  = statusLabel(d.dkim_pass,       d.dkim_total);
+    const mtaLabel    = d.mta_sts_enabled ? (d.mta_sts_mode ?? 'on') : 'Off';
+    const mtaColor: [number, number, number] = d.mta_sts_enabled ? PASS_COLOR : MUTED_COLOR;
+
+    // Alternate row background
+    const rowIdx = summaries.indexOf(d);
+    if (rowIdx % 2 === 0) {
+      doc.setFillColor(250, 250, 255);
+      doc.rect(MARGIN, y, COL_W, 8, 'F');
+    }
+
+    x = MARGIN;
+    doc.setFontSize(8);
+    doc.setTextColor(...DARK_COLOR);
+    // Domain name (truncate if long)
+    const domainText = d.domain.length > 22 ? d.domain.slice(0, 20) + '…' : d.domain;
+    doc.text(domainText, x + 1, y + 5.5);
+    x += cols[0];
+
+    doc.setTextColor(...policy.color);
+    doc.text(policy.label, x + 1, y + 5.5);
+    x += cols[1];
+
+    doc.setTextColor(...dmarcStatus.color);
+    doc.text(`${passRate(d.pass_messages, d.total_messages)} (${dmarcStatus.label})`, x + 1, y + 5.5);
+    x += cols[2];
+
+    doc.setTextColor(...spfStatus.color);
+    doc.text(`${passRate(d.spf_pass, d.spf_total)} (${spfStatus.label})`, x + 1, y + 5.5);
+    x += cols[3];
+
+    doc.setTextColor(...dkimStatus.color);
+    doc.text(`${passRate(d.dkim_pass, d.dkim_total)} (${dkimStatus.label})`, x + 1, y + 5.5);
+    x += cols[4];
+
+    doc.setTextColor(...mtaColor);
+    doc.text(mtaLabel, x + 1, y + 5.5);
+
+    y += 8;
+  }
+
+  return doc;
+}
+
+export function downloadPdfReport(data: PdfReportData, filename = 'email-auth-report.pdf'): void {
+  const doc = buildPdfReport(data);
+  doc.save(filename);
+}

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -77,10 +77,16 @@ export function Overview({ onUnauthorized }: Props) {
     if (pdfLoading || rows.length === 0) return;
     setPdfLoading(true);
     try {
-      const summaries = await Promise.all(
-        rows.map((r) => getDomainCheckSummary(r.domain.id))
-      );
-      downloadPdfReport({ summaries });
+      const [summaries, trendResults] = await Promise.all([
+        Promise.all(rows.map((r) => getDomainCheckSummary(r.domain.id))),
+        Promise.all(rows.map((r) => getDomainStats(r.domain.id, 90).catch(() => null))),
+      ]);
+      const trends: Record<number, import('../types').DailyStat[]> = {};
+      rows.forEach((r, i) => {
+        const statsData = trendResults[i];
+        if (statsData) trends[r.domain.id] = statsData.stats;
+      });
+      downloadPdfReport({ summaries, trends });
     } catch (e: any) {
       if (e.message === '401') { onUnauthorized(); return; }
       alert(`Failed to export PDF: ${e.message ?? 'Unknown error'}`);

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'preact/hooks';
-import { getDomains, getDomainStats, getWizardState } from '../api';
+import { getDomains, getDomainStats, getWizardState, getDomainCheckSummary } from '../api';
 import type { Domain, DomainStats, WizardState } from '../types';
+import { downloadPdfReport } from '../components/PdfReport';
 import { useIsMobile } from '../hooks';
 
 type Status = 'good' | 'warning' | 'danger';
@@ -69,7 +70,24 @@ export function Overview({ onUnauthorized }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [hovered, setHovered] = useState<number | null>(null);
+  const [pdfLoading, setPdfLoading] = useState(false);
   const mobile = useIsMobile();
+
+  async function handleExportPdf() {
+    if (pdfLoading || rows.length === 0) return;
+    setPdfLoading(true);
+    try {
+      const summaries = await Promise.all(
+        rows.map((r) => getDomainCheckSummary(r.domain.id))
+      );
+      downloadPdfReport({ summaries });
+    } catch (e: any) {
+      if (e.message === '401') { onUnauthorized(); return; }
+      alert(`Failed to export PDF: ${e.message ?? 'Unknown error'}`);
+    } finally {
+      setPdfLoading(false);
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -138,6 +156,15 @@ export function Overview({ onUnauthorized }: Props) {
         <a href="#/add" style={{ ...styles.addBtn, marginLeft: mobile ? '0' : 'auto', marginTop: mobile ? '0.25rem' : '0' }}>
           + Add domain
         </a>
+        {rows.length > 0 && (
+          <button
+            onClick={handleExportPdf}
+            disabled={pdfLoading}
+            style={{ ...styles.addBtn, background: '#374151', marginLeft: '0', marginTop: mobile ? '0.25rem' : '0', border: 'none' }}
+          >
+            {pdfLoading ? 'Generating…' : '↓ Export PDF'}
+          </button>
+        )}
       </div>
 
       {loading && <p style={styles.muted}>Loading…</p>}

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -191,6 +191,22 @@ export interface OnboardingStatus {
   };
 }
 
+export interface DomainCheckSummary {
+  domain_id: number;
+  domain: string;
+  dmarc_policy: string | null;
+  spf_record: string | null;
+  total_messages: number;
+  pass_messages: number;
+  fail_messages: number;
+  dkim_total: number;
+  dkim_pass: number;
+  spf_total: number;
+  spf_pass: number;
+  mta_sts_enabled: number; // 0 | 1
+  mta_sts_mode: string | null;
+}
+
 export type WizardStepState = 'not_started' | 'complete' | 'skipped';
 
 export interface WizardState {

--- a/dashboard/src/utils/pdfRecommendations.ts
+++ b/dashboard/src/utils/pdfRecommendations.ts
@@ -1,0 +1,86 @@
+import type { DomainCheckSummary } from '../types';
+
+export interface Recommendation {
+  domain: string;
+  severity: 'critical' | 'warning' | 'info';
+  message: string;
+}
+
+function passRate(pass: number, total: number): number | null {
+  if (total === 0) return null;
+  return pass / total;
+}
+
+export function getRecommendations(summary: DomainCheckSummary): Recommendation[] {
+  const recs: Recommendation[] = [];
+
+  // DMARC policy
+  if (!summary.dmarc_policy || summary.dmarc_policy === 'none') {
+    recs.push({
+      domain: summary.domain,
+      severity: 'critical',
+      message: 'DMARC policy is set to "none" (monitor only). Upgrade to "quarantine" or "reject" to protect against spoofing.',
+    });
+  } else if (summary.dmarc_policy === 'quarantine') {
+    recs.push({
+      domain: summary.domain,
+      severity: 'warning',
+      message: 'DMARC policy is "quarantine". Consider upgrading to "reject" once pass rates are stable.',
+    });
+  }
+
+  // DMARC pass rate
+  const dmarcRate = passRate(summary.pass_messages, summary.total_messages);
+  if (dmarcRate !== null && dmarcRate < 0.95) {
+    const pct = Math.round(dmarcRate * 100);
+    recs.push({
+      domain: summary.domain,
+      severity: dmarcRate < 0.7 ? 'critical' : 'warning',
+      message: `DMARC pass rate is ${pct}%. Investigate failing sources in the dashboard to improve deliverability.`,
+    });
+  }
+
+  // SPF pass rate
+  const spfRate = passRate(summary.spf_pass, summary.spf_total);
+  if (spfRate !== null && spfRate < 0.9) {
+    recs.push({
+      domain: summary.domain,
+      severity: 'warning',
+      message: `SPF pass rate is ${Math.round(spfRate * 100)}%. Ensure all sending services are included in your SPF record.`,
+    });
+  }
+
+  // DKIM pass rate
+  const dkimRate = passRate(summary.dkim_pass, summary.dkim_total);
+  if (dkimRate !== null && dkimRate < 0.9) {
+    recs.push({
+      domain: summary.domain,
+      severity: 'warning',
+      message: `DKIM pass rate is ${Math.round(dkimRate * 100)}%. Verify DKIM signing is configured for all sending services.`,
+    });
+  }
+
+  // No messages at all
+  if (summary.total_messages === 0) {
+    recs.push({
+      domain: summary.domain,
+      severity: 'info',
+      message: 'No DMARC reports received in the last 30 days. Verify the RUA address in your DMARC record is correct.',
+    });
+  }
+
+  // MTA-STS not enabled
+  if (!summary.mta_sts_enabled) {
+    recs.push({
+      domain: summary.domain,
+      severity: 'info',
+      message: 'MTA-STS is not enabled. Enabling it forces TLS for inbound mail delivery.',
+    });
+  }
+
+  return recs;
+}
+
+export function getAllRecommendations(summaries: DomainCheckSummary[]): Recommendation[] {
+  return summaries.flatMap(getRecommendations);
+}

--- a/specs/43-pdf-report-export/tasks.md
+++ b/specs/43-pdf-report-export/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: PDF Summary Report Export
+
+## Phase 1: Setup
+
+- [x] T001 Add `jspdf` dependency `dashboard/package.json`
+
+## Phase 2: US1 — Domain Health PDF (P1)
+
+- [x] T002 Add `getCheckSummary()` query (latest DMARC/SPF/DKIM/MTA-STS pass/fail per domain) `src/db/queries.ts`
+- [x] T003 Add `GET /api/domains/:id/check-summary` route (auth-protected, calls getCheckSummary) `src/api/router.ts`
+- [x] T004 Add `fetchCheckSummary()` API client function `dashboard/src/api.ts`
+- [x] T005 Create `PdfReport.ts` — jsPDF builder: title, date, per-domain status table, page breaks `dashboard/src/components/PdfReport.ts`
+- [x] T006 Add "Export PDF" button to Overview page; on click: fetch all domains + summaries, call PdfReport, trigger download `dashboard/src/pages/Overview.tsx`
+
+## Phase 3: US2 — Pass/Fail Rates & Recommendations (P2)
+
+- [x] T007 Create `pdfRecommendations.ts` — derive plain-language recommendations from check summary `dashboard/src/utils/pdfRecommendations.ts`
+- [x] T008 Extend `PdfReport.ts` — add aggregate pass/fail rates section + recommendations per domain `dashboard/src/components/PdfReport.ts`
+
+## Phase 4: US3 — Historical Trend (P3)
+
+- [x] T009 Fetch 90-day stats per domain during PDF export; aggregate daily stats into weekly pass rates `dashboard/src/pages/Overview.tsx`
+- [x] T010 Extend `PdfReport.ts` — add trend table (weekly pass %) per domain `dashboard/src/components/PdfReport.ts`
+
+## Phase 5: Tests & Polish
+
+- [x] T011 Unit tests for `pdfRecommendations.ts` (13 tests) `test/unit/pdfRecommendations.test.ts`
+- [x] T012 Unit tests for `getCheckSummary()` query (6 tests) `test/unit/checkSummary.test.ts`
+- [x] T013 Playwright smoke test: click "Export PDF", verify file download triggered `test/e2e/pdf-export.mjs`

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -63,6 +63,7 @@ import {
   getReportSourcesByDate,
   getDayReportSummary,
   getDomainExportData,
+  getCheckSummary,
   getAnomalySources,
   getAllSources,
   getSetting,
@@ -364,6 +365,20 @@ async function exportDomainData(env: Env, domainId: string): Promise<Response> {
       'Content-Disposition': `attachment; filename="${filename}"`,
     },
   });
+}
+
+async function getDomainCheckSummary(env: Env, domainId: string): Promise<Response> {
+  const id = parseInt(domainId, 10);
+  if (isNaN(id)) return err('invalid domain id', 400);
+
+  const domain = await getDomainById(env.DB, id);
+  if (!domain) return err('domain not found', 404);
+
+  const since = Math.floor(Date.now() / 1000) - 30 * 86400;
+  const summary = await getCheckSummary(env.DB, id, since);
+  if (!summary) return err('check summary not found', 404);
+
+  return json(summary);
 }
 
 async function getDomainReportByDate(env: Env, domainId: string, url: URL): Promise<Response> {
@@ -883,6 +898,11 @@ async function _handleApi(
     const exportMatch = path.match(/^\/api\/domains\/([^/]+)\/export$/);
     if (exportMatch && method === 'GET') {
       return await exportDomainData(env, exportMatch[1]);
+    }
+    // GET /api/domains/:id/check-summary — DMARC/SPF/DKIM/MTA-STS summary for PDF report
+    const checkSummaryMatch = path.match(/^\/api\/domains\/([^/]+)\/check-summary$/);
+    if (checkSummaryMatch && method === 'GET') {
+      return await getDomainCheckSummary(env, checkSummaryMatch[1]);
     }
     // GET /api/domains/:id/dns-check — check if user has added the _dmarc TXT record
     const dnsCheckMatch = path.match(/^\/api\/domains\/([^/]+)\/dns-check$/);

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -334,6 +334,53 @@ export function getDomainExportData(db: D1Database, domainId: number) {
   `).bind(domainId).all<ExportRow>();
 }
 
+// ── Check Summary (PDF report) ───────────────────────────────
+
+export interface DomainCheckSummary {
+  domain_id: number;
+  domain: string;
+  dmarc_policy: string | null;
+  spf_record: string | null;
+  // DMARC aggregate pass/fail (last 30 days)
+  total_messages: number;
+  pass_messages: number;
+  fail_messages: number;
+  // DKIM pass rate derived from report_records (last 30 days)
+  dkim_total: number;
+  dkim_pass: number;
+  // SPF pass rate derived from report_records (last 30 days)
+  spf_total: number;
+  spf_pass: number;
+  // MTA-STS
+  mta_sts_enabled: number; // 0 or 1
+  mta_sts_mode: string | null;
+}
+
+export function getCheckSummary(db: D1Database, domainId: number, since: number) {
+  return db.prepare(`
+    SELECT
+      d.id            AS domain_id,
+      d.domain,
+      d.dmarc_policy,
+      d.spf_record,
+      COALESCE(SUM(ar.total_count), 0) AS total_messages,
+      COALESCE(SUM(ar.pass_count),  0) AS pass_messages,
+      COALESCE(SUM(ar.fail_count),  0) AS fail_messages,
+      COALESCE(SUM(rr.count), 0)       AS dkim_total,
+      COALESCE(SUM(CASE WHEN rr.dkim_result = 'pass' THEN rr.count ELSE 0 END), 0) AS dkim_pass,
+      COALESCE(SUM(rr.count), 0)       AS spf_total,
+      COALESCE(SUM(CASE WHEN rr.spf_result  = 'pass' THEN rr.count ELSE 0 END), 0) AS spf_pass,
+      COALESCE(m.enabled, 0)           AS mta_sts_enabled,
+      m.mode                           AS mta_sts_mode
+    FROM domains d
+    LEFT JOIN aggregate_reports ar ON ar.domain_id = d.id AND ar.date_begin >= ?
+    LEFT JOIN report_records rr    ON rr.report_id = ar.id
+    LEFT JOIN mta_sts_config m     ON m.domain_id = d.id
+    WHERE d.id = ?
+    GROUP BY d.id, d.domain, d.dmarc_policy, d.spf_record, m.enabled, m.mode
+  `).bind(since, domainId).first<DomainCheckSummary>();
+}
+
 // ── Settings ─────────────────────────────────────────────────
 
 export function getSetting(db: D1Database, key: string) {

--- a/test/e2e/pdf-export.mjs
+++ b/test/e2e/pdf-export.mjs
@@ -1,0 +1,56 @@
+/**
+ * PDF Export smoke test — run via /test-prod
+ *
+ * Requires a running Chromium CDP on port 9222 and an authenticated session.
+ * Inject test session into D1 and set localStorage before running, or log in first.
+ *
+ * Usage: node test/e2e/pdf-export.mjs
+ */
+
+import { chromium } from '~/.local/share/fry-bot/node_modules/playwright-core/index.js';
+import { mkdir } from 'node:fs/promises';
+
+const BASE_URL = 'https://inbox-angel-worker.fellowshipdev.workers.dev';
+const SCREENSHOT_DIR = '/tmp/ia-test-pdf';
+
+await mkdir(SCREENSHOT_DIR, { recursive: true });
+
+let browser;
+try {
+  browser = await chromium.connectOverCDP('http://localhost:9222');
+  const ctx = browser.contexts()[0];
+  const page = await ctx.newPage();
+
+  // Step 1: Navigate to overview
+  await page.goto(`${BASE_URL}/#/`);
+  await page.waitForSelector('text=Export PDF', { timeout: 10_000 });
+  console.log('✓ Overview loaded with Export PDF button');
+  await page.screenshot({ path: `${SCREENSHOT_DIR}/01-overview-with-export-btn.png` });
+
+  // Step 2: Set up download listener BEFORE clicking
+  const downloadPromise = page.waitForEvent('download', { timeout: 30_000 });
+  await page.click('button:has-text("Export PDF")');
+
+  // Step 3: Wait for button to show "Generating…"
+  await page.waitForSelector('button:has-text("Generating")', { timeout: 5_000 });
+  console.log('✓ PDF generation started (Generating… state visible)');
+
+  // Step 4: Wait for download to trigger
+  const download = await downloadPromise;
+  const filename = download.suggestedFilename();
+  console.log(`✓ PDF download triggered: ${filename}`);
+
+  if (!filename.endsWith('.pdf')) {
+    throw new Error(`Expected .pdf filename, got: ${filename}`);
+  }
+
+  await page.screenshot({ path: `${SCREENSHOT_DIR}/02-pdf-downloaded.png` });
+
+  // Step 5: Button returns to normal state
+  await page.waitForSelector('button:has-text("Export PDF")', { timeout: 10_000 });
+  console.log('✓ Export PDF button returned to normal state after download');
+
+  console.log('\n✅ PDF export smoke test PASSED');
+} finally {
+  await browser?.close();
+}

--- a/test/unit/checkSummary.test.ts
+++ b/test/unit/checkSummary.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getCheckSummary } from '../../src/db/queries';
+
+function makeDb(firstResult: unknown = null) {
+  const firstFn = vi.fn().mockResolvedValue(firstResult);
+  const bindFn = vi.fn().mockReturnValue({ first: firstFn });
+  const prepareFn = vi.fn().mockReturnValue({ bind: bindFn });
+  return { prepare: prepareFn, _first: firstFn, _bind: bindFn };
+}
+
+describe('getCheckSummary', () => {
+  it('calls db.prepare with a SELECT query', () => {
+    const db = makeDb();
+    getCheckSummary(db as unknown as D1Database, 1, 0);
+    expect(db.prepare).toHaveBeenCalledOnce();
+    const sql: string = db.prepare.mock.calls[0][0];
+    expect(sql).toMatch(/SELECT/i);
+    expect(sql).toContain('domain_id');
+    expect(sql).toContain('dmarc_policy');
+  });
+
+  it('binds since and domainId parameters in the right order', () => {
+    const db = makeDb();
+    const since = Math.floor(Date.now() / 1000) - 30 * 86400;
+    getCheckSummary(db as unknown as D1Database, 42, since);
+    expect(db._bind).toHaveBeenCalledWith(since, 42);
+  });
+
+  it('returns the value from .first()', async () => {
+    const mockSummary = {
+      domain_id: 1, domain: 'example.com', dmarc_policy: 'reject',
+      spf_record: 'v=spf1 ~all', total_messages: 1000, pass_messages: 980,
+      fail_messages: 20, dkim_total: 1000, dkim_pass: 950,
+      spf_total: 1000, spf_pass: 960, mta_sts_enabled: 1, mta_sts_mode: 'enforce',
+    };
+    const db = makeDb(mockSummary);
+    const result = await getCheckSummary(db as unknown as D1Database, 1, 0);
+    expect(result).toEqual(mockSummary);
+  });
+
+  it('returns null when domain does not exist', async () => {
+    const db = makeDb(null);
+    const result = await getCheckSummary(db as unknown as D1Database, 999, 0);
+    expect(result).toBeNull();
+  });
+
+  it('query includes mta_sts_config join', () => {
+    const db = makeDb();
+    getCheckSummary(db as unknown as D1Database, 1, 0);
+    const sql: string = db.prepare.mock.calls[0][0];
+    expect(sql).toContain('mta_sts_config');
+  });
+
+  it('query includes report_records join for DKIM/SPF stats', () => {
+    const db = makeDb();
+    getCheckSummary(db as unknown as D1Database, 1, 0);
+    const sql: string = db.prepare.mock.calls[0][0];
+    expect(sql).toContain('report_records');
+    expect(sql).toContain('dkim_result');
+    expect(sql).toContain('spf_result');
+  });
+});

--- a/test/unit/pdfRecommendations.test.ts
+++ b/test/unit/pdfRecommendations.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { getRecommendations, getAllRecommendations } from '../../dashboard/src/utils/pdfRecommendations';
+import type { DomainCheckSummary } from '../../dashboard/src/types';
+
+function makeSummary(overrides: Partial<DomainCheckSummary> = {}): DomainCheckSummary {
+  return {
+    domain_id: 1,
+    domain: 'example.com',
+    dmarc_policy: 'reject',
+    spf_record: 'v=spf1 include:_spf.example.com ~all',
+    total_messages: 1000,
+    pass_messages: 980,
+    fail_messages: 20,
+    dkim_total: 1000,
+    dkim_pass: 970,
+    spf_total: 1000,
+    spf_pass: 960,
+    mta_sts_enabled: 1,
+    mta_sts_mode: 'enforce',
+    ...overrides,
+  };
+}
+
+describe('getRecommendations', () => {
+  it('returns no recommendations for a fully healthy domain', () => {
+    const recs = getRecommendations(makeSummary());
+    expect(recs).toHaveLength(0);
+  });
+
+  it('returns critical recommendation for dmarc_policy = none', () => {
+    const recs = getRecommendations(makeSummary({ dmarc_policy: 'none' }));
+    const critical = recs.find((r) => r.severity === 'critical' && r.message.includes('none'));
+    expect(critical).toBeDefined();
+  });
+
+  it('returns warning recommendation for dmarc_policy = quarantine', () => {
+    const recs = getRecommendations(makeSummary({ dmarc_policy: 'quarantine' }));
+    const warning = recs.find((r) => r.severity === 'warning' && r.message.includes('quarantine'));
+    expect(warning).toBeDefined();
+  });
+
+  it('returns no dmarc policy rec for reject policy', () => {
+    const recs = getRecommendations(makeSummary({ dmarc_policy: 'reject' }));
+    expect(recs.every((r) => !r.message.includes('policy'))).toBe(true);
+  });
+
+  it('returns critical for very low dmarc pass rate (<70%)', () => {
+    const recs = getRecommendations(makeSummary({ pass_messages: 600, total_messages: 1000 }));
+    const critical = recs.find((r) => r.severity === 'critical' && r.message.includes('60%'));
+    expect(critical).toBeDefined();
+  });
+
+  it('returns warning for moderately low dmarc pass rate (70-95%)', () => {
+    const recs = getRecommendations(makeSummary({ pass_messages: 800, total_messages: 1000 }));
+    const warning = recs.find((r) => r.severity === 'warning' && r.message.includes('80%'));
+    expect(warning).toBeDefined();
+  });
+
+  it('returns info when no messages received', () => {
+    const recs = getRecommendations(makeSummary({ total_messages: 0, pass_messages: 0, fail_messages: 0, dkim_total: 0, spf_total: 0 }));
+    const info = recs.find((r) => r.severity === 'info' && r.message.includes('No DMARC reports'));
+    expect(info).toBeDefined();
+  });
+
+  it('returns info when MTA-STS is disabled', () => {
+    const recs = getRecommendations(makeSummary({ mta_sts_enabled: 0 }));
+    const info = recs.find((r) => r.severity === 'info' && r.message.includes('MTA-STS'));
+    expect(info).toBeDefined();
+  });
+
+  it('returns warning for low SPF pass rate', () => {
+    const recs = getRecommendations(makeSummary({ spf_pass: 800, spf_total: 1000 }));
+    const warning = recs.find((r) => r.severity === 'warning' && r.message.includes('SPF'));
+    expect(warning).toBeDefined();
+  });
+
+  it('returns warning for low DKIM pass rate', () => {
+    const recs = getRecommendations(makeSummary({ dkim_pass: 800, dkim_total: 1000 }));
+    const warning = recs.find((r) => r.severity === 'warning' && r.message.includes('DKIM'));
+    expect(warning).toBeDefined();
+  });
+
+  it('all recommendations include domain name', () => {
+    const summary = makeSummary({ dmarc_policy: 'none', mta_sts_enabled: 0 });
+    const recs = getRecommendations(summary);
+    for (const r of recs) {
+      expect(r.domain).toBe('example.com');
+    }
+  });
+});
+
+describe('getAllRecommendations', () => {
+  it('flattens recommendations from multiple domains', () => {
+    const summaries = [
+      makeSummary({ domain: 'a.com', dmarc_policy: 'none' }),
+      makeSummary({ domain: 'b.com', mta_sts_enabled: 0 }),
+    ];
+    const recs = getAllRecommendations(summaries);
+    expect(recs.some((r) => r.domain === 'a.com')).toBe(true);
+    expect(recs.some((r) => r.domain === 'b.com')).toBe(true);
+  });
+
+  it('returns empty array for all-healthy domains', () => {
+    const recs = getAllRecommendations([makeSummary(), makeSummary({ domain_id: 2, domain: 'b.com' })]);
+    expect(recs).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a client-side PDF export of domain health summary for compliance officers and management
- New `GET /api/domains/:id/check-summary` API route aggregates DMARC/SPF/DKIM/MTA-STS pass/fail over 30 days
- **"Export PDF"** button on the Overview page fetches all domain summaries + 90-day trend data, then generates and downloads a PDF via jsPDF (no server-side rendering — compatible with Cloudflare Workers)
- PDF includes: per-domain protocol status table, aggregate pass/fail rates, plain-language policy recommendations, and weekly DMARC trend table

## Changes

| File | Change |
|------|--------|
| `src/db/queries.ts` | `getCheckSummary()` — 30-day DMARC/SPF/DKIM/MTA-STS aggregate query |
| `src/api/router.ts` | `GET /api/domains/:id/check-summary` route |
| `dashboard/src/api.ts` | `getDomainCheckSummary()` client function |
| `dashboard/src/types.ts` | `DomainCheckSummary` type |
| `dashboard/src/components/PdfReport.ts` | jsPDF builder — cover, domain table, recommendations, weekly trend |
| `dashboard/src/utils/pdfRecommendations.ts` | Plain-language recommendation logic |
| `dashboard/src/pages/Overview.tsx` | "Export PDF" button |
| `test/unit/pdfRecommendations.test.ts` | 13 unit tests |
| `test/unit/checkSummary.test.ts` | 6 unit tests |
| `test/e2e/pdf-export.mjs` | Playwright smoke test |

## Test Plan

- [x] `npm test` — 381 tests passing (was 362, +19 new)
- [ ] Manual: Click "Export PDF" on Overview, verify PDF downloads with all domains, pass rates, and recommendations
- [ ] Manual: Verify empty state (no domains) shows graceful message
- [ ] Manual: Verify PDF opens without authentication (client-side generation, no auth needed)

Closes #43