### PR TITLE
feat: dashboard UX quick wins — source IP hierarchy, score circle fix (#32)

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -16,12 +16,9 @@ import { ResetPassword } from './pages/ResetPassword';
 import { Onboarding } from './pages/Onboarding';
 import { SpfFlattenWizard } from './pages/SpfFlattenWizard';
 import { MtaStsWizard } from './pages/MtaStsWizard';
-<<<<<<< HEAD
 import { BulkImport } from './pages/BulkImport';
 import { CTDiscover } from './pages/CTDiscover';
-=======
 import { DmarcWizard } from './pages/DmarcWizard';
->>>>>>> origin/main
 import { AuthGate } from './AuthGate';
 import { getVersion, logout, type VersionInfo } from './api';
 

--- a/dashboard/src/AuthGate.tsx
+++ b/dashboard/src/AuthGate.tsx
@@ -80,7 +80,7 @@ export function AuthGate({ onSave }: Props) {
         setTelemetry(s.telemetry_default);
         if (s.turnstile_site_key) loadTurnstileScript();
       })
-      .catch(() => setStatus({ configured: false, prefill: { name: '', email: '' }, telemetry_default: false, turnstile_site_key: null }));
+      .catch(() => setStatus({ configured: false, prefill: { name: '', email: '' }, telemetry_default: false, turnstile_site_key: null, has_domain: false }));
   }, []);
 
   const submit = async (e: Event) => {

--- a/dashboard/src/pages/Domain.tsx
+++ b/dashboard/src/pages/Domain.tsx
@@ -116,6 +116,7 @@ export function DomainDetail({ id, onUnauthorized }: Props) {
   const [rolloutBusy, setRolloutBusy] = useState(false);
   const [rolloutError, setRolloutError] = useState<string | null>(null);
   const [showRolloutModal, setShowRolloutModal] = useState(false);
+  const [cfManaged, setCfManaged] = useState(false);
   const mobile = useIsMobile();
 
   // Initial load: domain info + failing sources (don't depend on chartDays)
@@ -603,10 +604,13 @@ export function DomainDetail({ id, onUnauthorized }: Props) {
               {sources.map((src) => (
                 <div key={src.source_ip} style={s.sourceCard}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                    <code style={s.code}>{src.source_ip}</code>
+                    {(src.org || src.base_domain)
+                      ? <span style={{ fontWeight: 600, fontSize: '0.875rem', color: '#111827' }}>{src.org ?? src.base_domain}</span>
+                      : <code style={s.code}>{src.source_ip}</code>
+                    }
                     <span style={s.muted}>{src.total.toLocaleString()} msg</span>
                   </div>
-                  {(src.org || src.base_domain) && <div style={{ fontSize: '0.8rem', color: '#6b7280', marginTop: '0.2rem' }}>{src.org ?? src.base_domain}</div>}
+                  {(src.org || src.base_domain) && <code style={{ fontFamily: 'monospace', fontSize: '0.75rem', color: '#9ca3af' }}>{src.source_ip}</code>}
                   {src.header_from && <div style={{ fontSize: '0.8rem', color: '#6b7280', marginTop: '0.2rem' }}>{src.header_from}</div>}
                 </div>
               ))}
@@ -615,7 +619,7 @@ export function DomainDetail({ id, onUnauthorized }: Props) {
             <table style={s.table}>
               <thead>
                 <tr>
-                  {['IP', 'Sending as', 'Failed messages'].map((h) => (
+                  {['Source', 'Sending as', 'Failed messages'].map((h) => (
                     <th key={h} style={s.th}>{h}</th>
                   ))}
                 </tr>
@@ -624,8 +628,11 @@ export function DomainDetail({ id, onUnauthorized }: Props) {
                 {sources.map((src) => (
                   <tr key={src.source_ip}>
                     <td style={s.td}>
-                      <code style={s.code}>{src.source_ip}</code>
-                      {(src.org || src.base_domain) && <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>{src.org ?? src.base_domain}</div>}
+                      {(src.org || src.base_domain)
+                        ? <span style={{ fontWeight: 600, color: '#111827' }}>{src.org ?? src.base_domain}</span>
+                        : <code style={s.code}>{src.source_ip}</code>
+                      }
+                      {(src.org || src.base_domain) && <code style={{ fontFamily: 'monospace', fontSize: '0.72rem', color: '#9ca3af' }}>{src.source_ip}</code>}
                     </td>
                     <td style={s.td}>{src.header_from ?? <span style={s.muted}>—</span>}</td>
                     <td style={{ ...s.td, textAlign: 'right' }}>{src.total.toLocaleString()}</td>

--- a/dashboard/src/pages/Onboarding.tsx
+++ b/dashboard/src/pages/Onboarding.tsx
@@ -842,7 +842,7 @@ function DmarcStep({ status, onNext, onSkip }: { status: OnboardingStatus; onNex
               {dmarc.auth_record.record_name && (
                 <div style={{ marginTop: '0.5rem' }}>
                   <p style={s.body}>Required record:</p>
-                  <CodeBlock value={`${dmarc.auth_record.record_name}  TXT  "v=DMARC1;"`} onCopy={() => copy(`${dmarc.auth_record.record_name}  TXT  "v=DMARC1;"`)} copied={copied} />
+                  <CodeBlock value={`${dmarc.auth_record.record_name}  TXT  "v=DMARC1;"`} onCopy={() => copy(`${dmarc.auth_record!.record_name}  TXT  "v=DMARC1;"`)} copied={copied} />
                   {cf_available && dmarc.current_record && (
                     <button
                       onClick={async () => {

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -28,8 +28,8 @@ const POLICY_LABEL: Record<string, string> = { none: 'none', quarantine: 'quar.'
 
 // Lighthouse-style score circle — SVG ring with number inside
 function ScoreCircle({ score }: { score: number | null }) {
-  const size = 36;
-  const r = 14;
+  const size = 40;
+  const r = 16;
   const cx = size / 2;
   const circumference = 2 * Math.PI * r;
   const color = score === null ? '#d1d5db'

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -198,6 +198,8 @@ export interface OnboardingStatus {
     destination_debug?: string;
     reports_domain: string | null;
     admin_email: string | null;
+    null_sender_spf?: boolean;
+    null_sender_dmarc?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary

Implements Steps 1 and 3 from issue #32 (Dashboard UX: 10-step improvement plan), plus a bug fix and TypeScript cleanup.

- **Step 1** (`Domain.tsx`): Flip source IP hierarchy — provider/org name is now primary (bold), raw IP is secondary monospace (muted). Both mobile card view and desktop table view updated. Column header renamed "IP" → "Source".
- **Step 3** (`Overview.tsx`): Fix `ScoreCircle` SVG — increase `size` from 36 to 40, `r` from 14 to 16. Gives 15px inner ring radius (vs 13), preventing 2-digit/3-digit score numbers from overlapping the ring.
- **Bug fix** (`Domain.tsx`): `setCfManaged` was called but `cfManaged` state was never declared — caused TypeScript error. Fixed by adding `const [cfManaged, setCfManaged] = useState(false)`.
- **Cleanup** (`App.tsx`): Resolved leftover merge conflict markers — now correctly imports BulkImport, CTDiscover, and DmarcWizard together.
- **TypeScript fixes** (`AuthGate.tsx`, `Onboarding.tsx`, `types.ts`): Fixed TS errors found during `npx tsc --noEmit`.

## Step 2 Status

DmarcWizard (`dashboard/src/pages/DmarcWizard.tsx`) was **already fully implemented** — graduated wizard with None → Quarantine → Reject flow, Cloudflare apply button, and WizardKit components. Domain.tsx already links to it. No code changes needed.

## Test Plan

- [x] `npm test` — 470 tests passing (31 test files)
- [x] `cd dashboard && npx tsc --noEmit` — no TypeScript errors

Closes #32 (Steps 1 and 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)