### PR TITLE
ci: add Cloudflare Worker deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+# Deploys the Cloudflare Worker on every push to main.
+#
+# Required secrets (set in GitHub repo Settings → Secrets and variables → Actions):
+#   CLOUDFLARE_API_TOKEN  — API token with Workers Scripts:Edit, D1:Edit, Email Sending:Edit,
+#                           Email Routing Rules:Edit, Zone:Read, DNS:Edit, Workers Routes:Edit
+#   CLOUDFLARE_ACCOUNT_ID — Your Cloudflare account ID (found in the dashboard sidebar)
+
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Workers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy


### PR DESCRIPTION
## Summary

Closes #62

Adds a GitHub Actions workflow that automatically deploys the Cloudflare Worker on every push to `main`.

**What it does:**
- Triggers on push to `main`
- Installs dependencies via `npm ci` (includes dashboard via `postinstall`)
- Uses `cloudflare/wrangler-action@v3` to run `wrangler deploy`, which runs the dashboard build defined in `wrangler.jsonc` before uploading

## Setup required

Before this workflow will succeed, add two secrets in **GitHub repo Settings → Secrets and variables → Actions**:

| Secret | Where to get it |
|--------|----------------|
| `CLOUDFLARE_API_TOKEN` | dash.cloudflare.com → My Profile → API Tokens — needs Workers Scripts:Edit, D1:Edit, Email Sending:Edit, Email Routing Rules:Edit, Zone:Read, DNS:Edit, Workers Routes:Edit |
| `CLOUDFLARE_ACCOUNT_ID` | dash.cloudflare.com → right sidebar |

## Test plan
- [ ] Secrets are set in GitHub repo settings
- [ ] Merge this PR → Actions tab shows a successful `Deploy` run
- [ ] Worker is live at its Cloudflare URL