### PR TITLE
chore: add FlowChad QA scaffold (.flowchad/ config + flows)

### DIFF
--- a/.flowchad/config.yml
+++ b/.flowchad/config.yml
@@ -1,0 +1,7 @@
+url: https://inbox-angel-worker.fellowshipdev.workers.dev
+persona: inbox-angel-qa
+
+smoketest:
+  flows:
+    - domain-source-ip
+    - score-circle

--- a/.flowchad/flows/domain-source-ip.yml
+++ b/.flowchad/flows/domain-source-ip.yml
@@ -1,0 +1,52 @@
+name: domain-source-ip
+description: >
+  Verify PR #61 Step 1 — Source IP hierarchy in Domain list table.
+  Provider/org name should appear as primary (bold), raw IP as secondary (muted monospace).
+  Column header should read "Source" (renamed from "IP").
+
+steps:
+  - name: open-dashboard
+    action: navigate
+    url: "{{TARGET_URL}}"
+    expect: InboxAngel dashboard loads — shows login or domain list page
+
+  - name: screenshot-landing
+    action: screenshot
+    expect: page renders without blank screen or JS errors
+
+  - name: find-login-form
+    action: find
+    selector: "input[type='email'], input[type='password'], button[type='submit'], a[href*='login']"
+    optional: true
+    expect: login form or link is present if authentication is required
+
+  - name: check-auth-wall
+    action: screenshot
+    expect: if auth wall visible, document it; if domain list visible, proceed
+
+  - name: find-domain-table
+    action: find
+    selector: "table, [class*='domain'], [class*='Domain']"
+    optional: true
+    expect: domain list table or card grid is visible
+
+  - name: find-source-column
+    action: find
+    selector: "th, [class*='header']"
+    optional: true
+    expect: >
+      Table header contains "Source" column (not "IP").
+      Verifies column rename from PR #61.
+
+  - name: screenshot-source-column
+    action: screenshot
+    expect: >
+      Source column visible. Provider/org name appears bold as primary text.
+      Raw IP address appears below in muted monospace style (smaller, gray).
+      This is the hierarchy change from PR #61 Step 1 in Domain.tsx.
+
+  - name: verify-mobile-card
+    action: scroll
+    direction: down
+    optional: true
+    expect: mobile card view also shows org/provider name primary, IP secondary

--- a/.flowchad/flows/score-circle.yml
+++ b/.flowchad/flows/score-circle.yml
@@ -1,0 +1,46 @@
+name: score-circle
+description: >
+  Verify PR #61 Step 3 — ScoreCircle SVG sizing fix in Overview page.
+  SVG size increased from 36→40, radius 14→16, giving 15px inner ring radius.
+  Score numbers (2-digit/3-digit) must not overlap the ring.
+
+steps:
+  - name: open-dashboard
+    action: navigate
+    url: "{{TARGET_URL}}"
+    expect: InboxAngel dashboard loads — shows login or overview page
+
+  - name: screenshot-landing
+    action: screenshot
+    expect: page renders without blank screen
+
+  - name: check-auth-wall
+    action: find
+    selector: "input[type='email'], input[type='password']"
+    optional: true
+    expect: if login required, document it; if overview visible, proceed
+
+  - name: find-overview-section
+    action: find
+    selector: "[class*='Overview'], [class*='score'], [class*='Score'], svg circle"
+    optional: true
+    expect: overview section or score circle SVG element is visible
+
+  - name: screenshot-score-area
+    action: screenshot
+    expect: >
+      ScoreCircle element visible. The score number (e.g. 85, 100) is centered
+      inside the ring without clipping. No number-ring overlap.
+      SVG viewBox should accommodate size=40, r=16 (inner radius 15px).
+
+  - name: inspect-score-circle
+    action: find
+    selector: "svg[class*='score'], svg[class*='Score'], circle[r]"
+    optional: true
+    expect: SVG circle element found with r=16 (updated from r=14 in PR #61)
+
+  - name: screenshot-final
+    action: screenshot
+    expect: >
+      Final evidence screenshot showing score circle with correct sizing.
+      Score text must be fully visible inside the ring without overlap.


### PR DESCRIPTION
## Summary

Adds `.flowchad/` QA automation scaffold, introduced and verified during FlowChad run for PR #61.

- `.flowchad/config.yml` — target URL, persona, smoketest flow list
- `.flowchad/flows/domain-source-ip.yml` — verifies SOURCE column rename + org/IP hierarchy (PR #61 Step 1)
- `.flowchad/flows/score-circle.yml` — verifies ScoreCircle SVG size=40 r=16 fix (PR #61 Step 3)

## QA Results (run against production 2026-04-17)

Both flows **PASSED** on https://inbox-angel-worker.fellowshipdev.workers.dev:

| Flow | Status | Key verification |
|------|--------|-----------------|
| domain-source-ip | ✅ PASS | SOURCE header + bold org / muted IP confirmed on Explore page |
| score-circle | ✅ PASS | r=16 confirmed via browser DOM; score "80" centered without ring overlap |

See full report: PR [fellowship-dev/inbox-angel-worker#61](https://github.com/fellowship-dev/inbox-angel-worker/pull/61#issuecomment-4266039039)

## Test plan

- [ ] Merge — no code changes, config-only
- [ ] FlowChad runner can pick up `smoketest.flows` from config on future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)