### PR TITLE
chore: sync speckit commands from spec-kit lean preset

### DIFF
--- a/.claude/commands/speckit.analyze.md
+++ b/.claude/commands/speckit.analyze.md
@@ -1,0 +1,35 @@
+---
+description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md.
+scripts:
+  sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
+  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Outline
+
+1. Read `.specify/feature.json` to get the feature directory path.
+
+2. Run `{SCRIPT}`. Parse `FEATURE_DIR`. Abort if `spec.md`, `plan.md`, or `tasks.md` is missing.
+
+3. **Load**: `spec.md` (requirements, success criteria), `plan.md` (architecture, phases), `tasks.md` (task IDs, phases, file paths), `.specify/memory/constitution.md` (principles). **READ-ONLY — do not modify any file.**
+
+4. **Detect issues** (max 50; severity: CRITICAL/HIGH/MEDIUM/LOW):
+   - Duplication — near-duplicate requirements
+   - Ambiguity — vague terms without metrics; TODO/placeholder markers
+   - Underspecification — stories missing acceptance criteria; tasks referencing undefined components
+   - Constitution alignment — any MUST conflict (always CRITICAL)
+   - Coverage gaps — requirements with 0 tasks; tasks with no mapped requirement
+   - Inconsistency — terminology drift; entity in plan but not spec; conflicting choices
+
+5. **Emit report** with stable IDs (e.g. `D1`, `A2`):
+   - Table: `ID | Category | Severity | Location | Summary | Recommendation`
+   - Coverage summary: `Requirement | Has Task? | Task IDs | Notes`
+   - Metrics: total requirements / tasks / coverage % / critical count
+
+6. If CRITICAL findings exist, recommend resolving before `__SPECKIT_COMMAND_IMPLEMENT__`. Otherwise list improvements and offer "Suggest concrete edits for top N?" — never apply automatically.

--- a/.claude/commands/speckit.analyze.md
+++ b/.claude/commands/speckit.analyze.md
@@ -1,8 +1,5 @@
 ---
 description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md.
-scripts:
-  sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
-  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
 ---
 
 ## User Input
@@ -13,13 +10,11 @@ $ARGUMENTS
 
 ## Outline
 
-1. Read `.specify/feature.json` to get the feature directory path.
+1. Read `.specify/feature.json` to get the feature directory path. Abort if `spec.md`, `plan.md`, or `tasks.md` is missing.
 
-2. Run `{SCRIPT}`. Parse `FEATURE_DIR`. Abort if `spec.md`, `plan.md`, or `tasks.md` is missing.
+2. **Load**: `spec.md` (requirements, success criteria), `plan.md` (architecture, phases), `tasks.md` (task IDs, phases, file paths), `.specify/memory/constitution.md` (principles). **READ-ONLY — do not modify any file.**
 
-3. **Load**: `spec.md` (requirements, success criteria), `plan.md` (architecture, phases), `tasks.md` (task IDs, phases, file paths), `.specify/memory/constitution.md` (principles). **READ-ONLY — do not modify any file.**
-
-4. **Detect issues** (max 50; severity: CRITICAL/HIGH/MEDIUM/LOW):
+3. **Detect issues** (max 50; severity: CRITICAL/HIGH/MEDIUM/LOW):
    - Duplication — near-duplicate requirements
    - Ambiguity — vague terms without metrics; TODO/placeholder markers
    - Underspecification — stories missing acceptance criteria; tasks referencing undefined components
@@ -27,9 +22,9 @@ $ARGUMENTS
    - Coverage gaps — requirements with 0 tasks; tasks with no mapped requirement
    - Inconsistency — terminology drift; entity in plan but not spec; conflicting choices
 
-5. **Emit report** with stable IDs (e.g. `D1`, `A2`):
+4. **Emit report** with stable IDs (e.g. `D1`, `A2`):
    - Table: `ID | Category | Severity | Location | Summary | Recommendation`
    - Coverage summary: `Requirement | Has Task? | Task IDs | Notes`
    - Metrics: total requirements / tasks / coverage % / critical count
 
-6. If CRITICAL findings exist, recommend resolving before `__SPECKIT_COMMAND_IMPLEMENT__`. Otherwise list improvements and offer "Suggest concrete edits for top N?" — never apply automatically.
+5. If CRITICAL findings exist, recommend resolving before `/speckit.implement`. Otherwise list improvements and offer "Suggest concrete edits for top N?" — never apply automatically.

--- a/.claude/commands/speckit.constitution.md
+++ b/.claude/commands/speckit.constitution.md
@@ -1,0 +1,15 @@
+---
+description: Create or update the project constitution.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Outline
+
+1. Create or update the project constitution and store it in `.specify/memory/constitution.md`.
+   - Project name, guiding principles, non-negotiable rules
+   - Derive from user input and existing repo context (README, docs)

--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -1,0 +1,22 @@
+---
+description: Execute the implementation plan by processing all tasks in tasks.md.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Outline
+
+1. Read `.specify/feature.json` to get the feature directory path.
+
+2. **Load context**: `.specify/memory/constitution.md` and `<feature_directory>/spec.md` and `<feature_directory>/plan.md` and `<feature_directory>/tasks.md`.
+
+3. **Execute tasks** in order:
+   - Complete each task before moving to the next
+   - Mark completed tasks by changing `- [ ]` to `- [x]` in `<feature_directory>/tasks.md`
+   - Halt on failure and report the issue
+
+4. **Validate**: Verify all tasks are completed and the implementation matches the spec.

--- a/.claude/commands/speckit.plan.md
+++ b/.claude/commands/speckit.plan.md
@@ -1,0 +1,19 @@
+---
+description: Create a plan and store it in plan.md.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Outline
+
+1. Read `.specify/feature.json` to get the feature directory path.
+
+2. **Load context**: `.specify/memory/constitution.md` and `<feature_directory>/spec.md`.
+
+3. Create an implementation plan and store it in `<feature_directory>/plan.md`.
+   - Technical context: tech stack, dependencies, project structure
+   - Design decisions, architecture, file structure

--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -1,0 +1,23 @@
+---
+description: Create a specification and store it in spec.md.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Outline
+
+1. **Ask the user** for the feature directory path (e.g., `specs/my-feature`). Do not proceed until provided.
+
+2. Create the directory and write `.specify/feature.json`:
+   ```json
+   { "feature_directory": "<feature_directory>" }
+   ```
+
+3. Create a specification from the user input and store it in `<feature_directory>/spec.md`.
+   - Overview, functional requirements, user scenarios, success criteria
+   - Every requirement must be testable
+   - Make informed defaults for unspecified details

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -1,0 +1,19 @@
+---
+description: Create the tasks needed for implementation and store them in tasks.md.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Outline
+
+1. Read `.specify/feature.json` to get the feature directory path.
+
+2. **Load context**: `.specify/memory/constitution.md` and `<feature_directory>/spec.md` and `<feature_directory>/plan.md`.
+
+3. Create dependency-ordered implementation tasks and store them in `<feature_directory>/tasks.md`.
+   - Every task uses checklist format: `- [ ] [TaskID] Description with file path`
+   - Organized by phase: setup, foundational, user stories in priority order, polish

--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ dashboard/node_modules
 # https://github.com/Fellowship-dev/agents-gitignore
 CLAUDE.md
 .claude/
+!.claude/commands/
 AGENTS.md
 AGENTS.override.md
 codex.md


### PR DESCRIPTION
## Summary

- Adds speckit commands from `fellowship-dev/spec-kit` lean preset (initial install)
- Includes: `speckit.analyze.md`, `speckit.specify.md`, `speckit.plan.md`, `speckit.tasks.md`, `speckit.implement.md`, `speckit.constitution.md`
- All templates are terse rewrites: specify ≤50 lines, plan ≤50, tasks ≤40, implement ≤40, analyze ≤40

Closes https://github.com/fellowship-dev/pylot/issues/239

Related: fellowship-dev/spec-kit#6

## Test plan

- [ ] Verify `/speckit.analyze` command is available and describes a READ-ONLY analysis phase
- [ ] Verify all speckit commands appear in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)