### PR TITLE
chore: sync speckit commands from spec-kit HEAD

### DIFF
--- a/.claude/commands/speckit.analyze.md
+++ b/.claude/commands/speckit.analyze.md
@@ -1,8 +1,5 @@
 ---
-description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
-scripts:
-  sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
-  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
+description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md.
 ---
 
 ## User Input
@@ -11,85 +8,23 @@ scripts:
 $ARGUMENTS
 ```
 
-You **MUST** consider the user input before proceeding (if not empty).
+## Outline
 
-## Pre-Execution
+1. Read `.specify/feature.json` to get the feature directory path. Abort if `spec.md`, `plan.md`, or `tasks.md` is missing.
 
-Run `hooks.before_analyze` from `.specify/extensions.yml` if present.
+2. **Load**: `spec.md` (requirements, success criteria), `plan.md` (architecture, phases), `tasks.md` (task IDs, phases, file paths), `.specify/memory/constitution.md` (principles). **READ-ONLY — do not modify any file.**
 
-## Constraints
+3. **Detect issues** (max 50; severity: CRITICAL/HIGH/MEDIUM/LOW):
+   - Duplication — near-duplicate requirements
+   - Ambiguity — vague terms without metrics; TODO/placeholder markers
+   - Underspecification — stories missing acceptance criteria; tasks referencing undefined components
+   - Constitution alignment — any MUST conflict (always CRITICAL)
+   - Coverage gaps — requirements with 0 tasks; tasks with no mapped requirement
+   - Inconsistency — terminology drift; entity in plan but not spec; conflicting choices
 
-**READ-ONLY.** Do not modify any files. Output a single analysis report.
+4. **Emit report** with stable IDs (e.g. `D1`, `A2`):
+   - Table: `ID | Category | Severity | Location | Summary | Recommendation`
+   - Coverage summary: `Requirement | Has Task? | Task IDs | Notes`
+   - Metrics: total requirements / tasks / coverage % / critical count
 
-**Constitution is authoritative.** Conflicts with `/memory/constitution.md` → always CRITICAL. Principles change only via `__SPECKIT_COMMAND_CONSTITUTION__`.
-
-## Steps
-
-1. **Setup**: run `{SCRIPT}`. Parse `FEATURE_DIR` + `AVAILABLE_DOCS`. Derive absolute paths:
-   - `SPEC = FEATURE_DIR/spec.md`
-   - `PLAN = FEATURE_DIR/plan.md`
-   - `TASKS = FEATURE_DIR/tasks.md`
-
-   Abort if any is missing.
-
-2. **Load minimally**:
-   - `spec.md` → Overview, Functional Requirements, Success Criteria, User Stories, Edge Cases
-   - `plan.md` → Architecture, data-model refs, phases, constraints
-   - `tasks.md` → IDs, descriptions, phases, `[P]`, file paths
-   - `constitution.md` → principles
-
-3. **Build internal models** (don't emit):
-   - Requirements inventory: FR-###, SC-### as keys (skip non-buildable outcomes like "reduce tickets by 50%")
-   - User-action inventory with acceptance criteria
-   - Task → requirement mapping
-   - Constitution MUST/SHOULD statements
-
-4. **Detection passes** (max 50 findings; overflow summarized):
-   - **A. Duplication** — near-duplicate requirements; flag worse phrasing
-   - **B. Ambiguity** — vague adjectives ("fast", "robust") without metrics; TODO/TKTK/`<placeholder>`
-   - **C. Underspecification** — verbs with no object; stories missing acceptance; tasks referencing undefined components
-   - **D. Constitution alignment** — any conflict with MUST principle; missing mandated sections
-   - **E. Coverage gaps** — requirements with 0 tasks; tasks with no mapped requirement; buildable SCs not reflected in tasks
-   - **F. Inconsistency** — terminology drift; entity mentioned in plan but not spec (or vice versa); task ordering contradictions; conflicting choices (Next.js vs Vue)
-
-5. **Severity**:
-   - CRITICAL — constitution MUST violation, missing core artifact, zero-coverage blocking baseline
-   - HIGH — duplicate/conflicting requirement, ambiguous security/perf attribute, untestable acceptance
-   - MEDIUM — terminology drift, missing NFR coverage, underspecified edge case
-   - LOW — wording, minor redundancy
-
-6. **Emit report**:
-
-   ```
-   ## Specification Analysis Report
-
-   | ID | Category | Severity | Location | Summary | Recommendation |
-
-   ## Coverage Summary
-
-   | Requirement | Has Task? | Task IDs | Notes |
-
-   ## Constitution Alignment Issues
-   ## Unmapped Tasks
-   ## Metrics
-   - Total requirements / tasks / coverage % / ambiguity / duplication / critical count
-   ```
-
-   Stable IDs prefixed by category initial (`D1`, `A2`, …).
-
-7. **Next actions**:
-   - CRITICAL present → recommend resolving before `__SPECKIT_COMMAND_IMPLEMENT__`
-   - Only LOW/MEDIUM → may proceed; list improvement suggestions
-   - Suggest specific follow-up commands
-
-8. **Offer remediation**: ask "Suggest concrete edits for top N?" — never apply automatically.
-
-9. Run `hooks.after_analyze` if present.
-
-## Principles
-
-- **Never modify files.**
-- **Never hallucinate missing sections** — report them as absent.
-- **Constitution violations are always CRITICAL.**
-- Cite specific instances, not generic patterns.
-- Deterministic: same input → same IDs and counts.
+5. If CRITICAL findings exist, recommend resolving before `__SPECKIT_COMMAND_IMPLEMENT__`. Otherwise list improvements and offer "Suggest concrete edits for top N?" — never apply automatically.

--- a/.claude/commands/speckit.checklist.md
+++ b/.claude/commands/speckit.checklist.md
@@ -39,9 +39,15 @@ Checklists validate **requirements writing quality** — not implementation.
 
 4. **Generate checklist** at `FEATURE_DIR/checklists/<domain>.md`:
    - Start from `templates/checklist-template.md`.
-   - 10–20 items grouped by quality dimension (completeness, clarity, consistency, coverage, edge cases).
+   - 10–20 items grouped by quality dimension. Use these six:
+     - **Completeness**: are all needed requirements present?
+     - **Clarity**: are they unambiguous and specific?
+     - **Consistency**: do they agree with each other?
+     - **Measurability**: can each be objectively verified?
+     - **Coverage**: are all flows / scenario classes addressed?
+     - **Edge Cases**: are boundary and failure conditions defined?
    - Each item is a yes/no question targeting requirement quality.
-   - Tie each question to specific spec sections where possible.
+   - Tie each question to specific spec sections where possible (`[Spec §X.Y]` or `[Gap]`).
 
 5. **Report**: path to checklist file, item count, grouping summary.
 

--- a/.claude/commands/speckit.constitution.md
+++ b/.claude/commands/speckit.constitution.md
@@ -1,9 +1,5 @@
 ---
-description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
-handoffs:
-  - label: Build Specification
-    agent: speckit.specify
-    prompt: Implement the feature specification based on the updated constitution. I want to build...
+description: Create or update the project constitution.
 ---
 
 ## User Input
@@ -12,65 +8,8 @@ handoffs:
 $ARGUMENTS
 ```
 
-You **MUST** consider the user input before proceeding (if not empty).
+## Outline
 
-## Pre-Execution
-
-Run `hooks.before_constitution` from `.specify/extensions.yml` if present.
-
-## Target
-
-Fill or amend `.specify/memory/constitution.md` from `[ALL_CAPS_TOKEN]` placeholders. If missing, copy `.specify/templates/constitution-template.md` first.
-
-## Steps
-
-1. **Load** existing constitution. Identify every `[ALL_CAPS]` placeholder. User may specify fewer/more principles than the template — respect that.
-
-2. **Collect values**:
-   - Prefer user input.
-   - Else infer from repo (README, docs, prior versions).
-   - `RATIFICATION_DATE` = original adoption date (ask or mark `TODO` if unknown).
-   - `LAST_AMENDED_DATE` = today iff changes made.
-   - `CONSTITUTION_VERSION` semver bump:
-     - MAJOR — backward-incompatible removal/redefinition
-     - MINOR — new principle/section or materially expanded guidance
-     - PATCH — wording, typos, non-semantic refinements
-   - Ambiguous bump → propose rationale first.
-
-3. **Draft**:
-   - Replace every placeholder with concrete text. Intentional unresolved placeholders must be justified.
-   - Each Principle: succinct name, paragraph or bullets of non-negotiable rules, rationale if non-obvious.
-   - Governance section: amendment procedure, versioning policy, compliance review.
-
-4. **Propagate**:
-   - `.specify/templates/plan-template.md` — align "Constitution Check" with updated principles.
-   - `.specify/templates/spec-template.md` — align mandatory sections/constraints.
-   - `.specify/templates/tasks-template.md` — align task categorization.
-   - `.specify/templates/commands/*.md` — remove outdated agent-specific references.
-   - `README.md` / runtime docs — update principle references.
-
-5. **Sync Impact Report** as HTML comment at top of constitution:
-   - Version change: old → new
-   - Modified principles (renames noted)
-   - Added / removed sections
-   - Templates updated (✅) or pending (⚠) with paths
-   - Deferred TODOs
-
-6. **Validate before write**:
-   - No unexplained bracket tokens.
-   - Version line matches report.
-   - Dates in ISO format `YYYY-MM-DD`.
-   - Principles declarative + testable (`MUST`/`SHOULD` instead of `should`).
-
-7. **Write** back to `.specify/memory/constitution.md` (overwrite).
-
-8. **Report**: new version + bump rationale, files flagged for follow-up, suggested commit message (e.g., `docs: amend constitution to vX.Y.Z`).
-
-9. Run `hooks.after_constitution` if present.
-
-## Rules
-
-- Preserve heading hierarchy exactly.
-- Single blank line between sections. No trailing whitespace.
-- Missing critical info → `TODO(<FIELD>): explanation` + list under deferred items.
-- Never create a new file — always amend `.specify/memory/constitution.md`.
+1. Create or update the project constitution and store it in `.specify/memory/constitution.md`.
+   - Project name, guiding principles, non-negotiable rules
+   - Derive from user input and existing repo context (README, docs)

--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -1,8 +1,5 @@
 ---
-description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
-scripts:
-  sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
-  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
+description: Execute the implementation plan by processing all tasks in tasks.md.
 ---
 
 ## User Input
@@ -11,55 +8,15 @@ scripts:
 $ARGUMENTS
 ```
 
-You **MUST** consider the user input before proceeding (if not empty).
+## Outline
 
-## Pre-Execution
+1. Read `.specify/feature.json` to get the feature directory path.
 
-Run `hooks.before_implement` from `.specify/extensions.yml` if present.
+2. **Load context**: `.specify/memory/constitution.md` and `<feature_directory>/spec.md` and `<feature_directory>/plan.md` and `<feature_directory>/tasks.md`.
 
-## Steps
+3. **Execute tasks** in order:
+   - Complete each task before moving to the next
+   - Mark completed tasks by changing `- [ ]` to `- [x]` in `<feature_directory>/tasks.md`
+   - Halt on failure and report the issue
 
-1. **Setup**: run `{SCRIPT}`. Parse `FEATURE_DIR` and `AVAILABLE_DOCS`. Escape quotes in args: `'I'\''m Groot'`.
-
-2. **Checklist gate** (if `FEATURE_DIR/checklists/` exists):
-   - Count `- [ ]` (incomplete) vs `- [X]|- [x]` (done) per checklist.
-   - Emit a status table (`| Checklist | Total | Completed | Incomplete | Status |`).
-   - **If any incomplete** → stop and ask: `"Some checklists are incomplete. Proceed anyway? (yes/no)"`. Halt on `no`/`stop`.
-   - **If all pass** → proceed.
-
-3. **Load context**:
-   - Required: `tasks.md`, `plan.md`
-   - Optional: `data-model.md`, `contracts/`, `research.md`, `quickstart.md`
-
-4. **Verify ignore files** — create/append as needed based on detected tooling:
-   - git repo → `.gitignore`
-   - `Dockerfile*` or Docker in plan → `.dockerignore`
-   - `.eslintrc*` → `.eslintignore`; `.prettierrc*` → `.prettierignore`
-   - Language/tool patterns as appropriate (node_modules, __pycache__, target/, bin/, etc.)
-   - Always include `.DS_Store`, `*.log`, `.env*`
-
-5. **Parse tasks.md**: extract phases, dependencies, task details (ID, file paths, `[P]` markers), execution order.
-
-6. **Execute**:
-   - Phase-by-phase; finish phase N before N+1.
-   - Sequential tasks in order. `[P]` tasks may run in parallel.
-   - Tests before their corresponding implementation if TDD was requested.
-   - Tasks hitting the same file are serial regardless of `[P]`.
-
-7. **Progress**:
-   - Mark each completed task `- [X]` in `tasks.md`.
-   - Report after each task.
-   - Halt if a non-parallel task fails. For `[P]` failures, continue with survivors + list failures.
-
-8. **Completion**:
-   - Verify all tasks done.
-   - Check implementation matches spec.
-   - Confirm tests pass.
-   - Final status report with summary of work.
-
-9. Run `hooks.after_implement` if present.
-
-## Rules
-
-- If `tasks.md` is missing or incomplete, suggest `__SPECKIT_COMMAND_TASKS__` first.
-- Use absolute paths for file ops, project-relative for references.
+4. **Validate**: Verify all tasks are completed and the implementation matches the spec.

--- a/.claude/commands/speckit.plan.md
+++ b/.claude/commands/speckit.plan.md
@@ -1,16 +1,5 @@
 ---
-description: Execute the implementation planning workflow using the plan template to generate design artifacts.
-handoffs:
-  - label: Create Tasks
-    agent: speckit.tasks
-    prompt: Break the plan into tasks
-    send: true
-  - label: Create Checklist
-    agent: speckit.checklist
-    prompt: Create a checklist for the following domain...
-scripts:
-  sh: scripts/bash/setup-plan.sh --json
-  ps: scripts/powershell/setup-plan.ps1 -Json
+description: Create a plan and store it in plan.md.
 ---
 
 ## User Input
@@ -19,41 +8,12 @@ scripts:
 $ARGUMENTS
 ```
 
-You **MUST** consider the user input before proceeding (if not empty).
+## Outline
 
-## Pre-Execution
+1. Read `.specify/feature.json` to get the feature directory path.
 
-Run `hooks.before_plan` from `.specify/extensions.yml` if present.
+2. **Load context**: `.specify/memory/constitution.md` and `<feature_directory>/spec.md`.
 
-## Output constraint
-
-**plan.md must be ≤60 lines.** Tables and bullets over prose.
-
-## Steps
-
-1. **Setup**: Run `{SCRIPT}`. Parse JSON for `FEATURE_SPEC`, `IMPL_PLAN`, `SPECS_DIR`, `BRANCH`. Escape single quotes in args: `'I'\''m Groot'`.
-
-2. **Load context**: read `FEATURE_SPEC` and `/memory/constitution.md`. Load `IMPL_PLAN` template (already copied).
-
-3. **Phase 0 — Research**: for each `[NEEDS CLARIFICATION]` in Technical Context, for each dependency, for each integration: generate a research task. Consolidate in `research.md`:
-   - Decision: what was chosen
-   - Rationale: why
-   - Alternatives: what else was considered
-
-4. **Phase 1 — Design**:
-   - Extract entities from spec → `data-model.md` (fields, relationships, state transitions)
-   - Define interface contracts (if external interfaces exist) → `contracts/` (API, CLI schema, UI contracts — pick format for project type)
-   - Write `quickstart.md` with happy-path smoke-test steps
-   - Update the `<!-- SPECKIT START -->` block in `__CONTEXT_FILE__` to point to the IMPL_PLAN
-
-5. **Constitution gates**: evaluate before + after design. ERROR on unjustified violations or unresolved clarifications.
-
-6. **Stop and report**: branch, `IMPL_PLAN` path, artifacts (research.md, data-model.md, contracts/, quickstart.md). Do NOT generate tasks here.
-
-7. Run `hooks.after_plan` if present.
-
-## Rules
-
-- Absolute paths for filesystem ops; project-relative for doc references.
-- ERROR on gate failures or unresolved `[NEEDS CLARIFICATION]`.
-- Skip `contracts/` for internal-only projects (build scripts, one-off tools).
+3. Create an implementation plan and store it in `<feature_directory>/plan.md`.
+   - Technical context: tech stack, dependencies, project structure
+   - Design decisions, architecture, file structure

--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -1,13 +1,5 @@
 ---
-description: Create or update the feature specification from a natural language feature description.
-handoffs:
-  - label: Build Technical Plan
-    agent: speckit.plan
-    prompt: Create a plan for the spec. I am building with...
-  - label: Clarify Spec Requirements
-    agent: speckit.clarify
-    prompt: Clarify specification requirements
-    send: true
+description: Create a specification and store it in spec.md.
 ---
 
 ## User Input
@@ -16,61 +8,16 @@ handoffs:
 $ARGUMENTS
 ```
 
-You **MUST** consider the user input before proceeding (if not empty).
+## Outline
 
-## Pre-Execution
+1. **Ask the user** for the feature directory path (e.g., `specs/my-feature`). Do not proceed until provided.
 
-Check `.specify/extensions.yml` for `hooks.before_specify` entries:
-- For each executable hook, output the following based on its `optional` flag: prompt optional hooks, auto-execute mandatory hooks.
-- Skip if no hooks registered or file absent.
+2. Create the directory and write `.specify/feature.json`:
+   ```json
+   { "feature_directory": "<feature_directory>" }
+   ```
 
-## Output constraint
-
-**spec.md must be ≤50 lines.** Terse, testable, no prose.
-
-## Steps
-
-1. **Short name** (2-4 words, kebab-case) from the feature description. Action-noun format (`add-user-auth`, `fix-payment-timeout`). Preserve acronyms (OAuth2, JWT).
-
-2. **Branch creation** (optional): if a `before_specify` hook ran, it emits `BRANCH_NAME` + `FEATURE_NUM` JSON. Note but don't block on it. If user provided `GIT_BRANCH_NAME`, pass through.
-
-3. **Spec directory**: resolve `SPECIFY_FEATURE_DIRECTORY`:
-   - If user provided one, use it.
-   - Else check `.specify/init-options.json` for `branch_numbering`:
-     - `"timestamp"`: prefix = `YYYYMMDD-HHMMSS`
-     - `"sequential"` or absent: prefix = `NNN` (next 3-digit after scanning `specs/`)
-   - Directory = `specs/<prefix>-<short-name>`
-
-4. **Create**: `mkdir -p SPECIFY_FEATURE_DIRECTORY`, copy `templates/spec-template.md` → `SPECIFY_FEATURE_DIRECTORY/spec.md`, set `SPEC_FILE`. Persist `{ "feature_directory": "<resolved path>" }` to `.specify/feature.json`.
-
-5. **Fill spec.md** from the feature description:
-   - 2-4 user stories (P1, P2, P3) — one sentence each + Given/When/Then
-   - 3-5 functional requirements — testable, no tech details
-   - 3-4 success criteria — measurable, tech-agnostic
-   - Max 3 `[NEEDS CLARIFICATION: ...]` markers (scope > security > UX > tech)
-   - Reasonable defaults for unspecified details (note in Assumptions)
-
-6. **Validate**: ≤50 lines, no implementation details, testable requirements.
-
-7. **Quality checklist** at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md`: content-quality, requirement-completeness, feature-readiness (see checklist template). Fail items → edit spec, re-validate (max 3 iterations).
-
-8. **Open questions**: if `[NEEDS CLARIFICATION]` markers remain (max 3), present each as a markdown table with 3 suggested answers + "Custom" option. Wait for user response. Replace markers with answers. Re-validate.
-
-9. **Report**: `SPECIFY_FEATURE_DIRECTORY`, `SPEC_FILE`, checklist summary, next phase (`__SPECKIT_COMMAND_CLARIFY__` or `__SPECKIT_COMMAND_PLAN__`).
-
-10. Run `hooks.after_specify` if present.
-
-## Rules
-
-- **WHAT and WHY**, not HOW (no tech stack, APIs, code).
-- For business stakeholders, not developers.
-- Success criteria are measurable + tech-agnostic:
-  - ✅ "Users complete checkout in under 3 minutes"
-  - ❌ "API response time under 200ms"
-- Remove sections that don't apply; don't leave "N/A".
-
-## Examples
-
-```bash
-/speckit-specify Build an application that organizes photos into albums by date
-```
+3. Create a specification from the user input and store it in `<feature_directory>/spec.md`.
+   - Overview, functional requirements, user scenarios, success criteria
+   - Every requirement must be testable
+   - Make informed defaults for unspecified details

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -1,17 +1,5 @@
 ---
-description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
-handoffs:
-  - label: Analyze For Consistency
-    agent: speckit.analyze
-    prompt: Run a project analysis for consistency
-    send: true
-  - label: Implement Project
-    agent: speckit.implement
-    prompt: Start the implementation in phases
-    send: true
-scripts:
-  sh: scripts/bash/check-prerequisites.sh --json
-  ps: scripts/powershell/check-prerequisites.ps1 -Json
+description: Create the tasks needed for implementation and store them in tasks.md.
 ---
 
 ## User Input
@@ -20,65 +8,12 @@ scripts:
 $ARGUMENTS
 ```
 
-You **MUST** consider the user input before proceeding (if not empty).
+## Outline
 
-## Pre-Execution
+1. Read `.specify/feature.json` to get the feature directory path.
 
-Run `hooks.before_tasks` from `.specify/extensions.yml` if present.
+2. **Load context**: `.specify/memory/constitution.md` and `<feature_directory>/spec.md` and `<feature_directory>/plan.md`.
 
-## Output constraint
-
-**Tasks MUST use the checklist format** (see below). No prose. Absolute file paths per task.
-
-## Steps
-
-1. **Setup**: run `{SCRIPT}`. Parse `FEATURE_DIR` and `AVAILABLE_DOCS`. Escape quotes in args: `'I'\''m Groot'`.
-
-2. **Load docs** from `FEATURE_DIR`:
-   - Required: `plan.md` (stack, structure), `spec.md` (user stories with priorities)
-   - Optional: `data-model.md`, `contracts/`, `research.md`, `quickstart.md`
-   - Not all projects have all docs — generate from what's available.
-
-3. **Extract**:
-   - Tech stack, libraries, structure from `plan.md`
-   - User stories with P1/P2/P3 priority from `spec.md`
-   - Entities from `data-model.md` → map to stories
-   - Interface contracts → map to stories
-   - Decisions from `research.md` → setup tasks
-
-4. **Generate `tasks.md`** from `templates/tasks-template.md`:
-   - Phase 1: Setup (project init)
-   - Phase 2: Foundational (blocks all stories)
-   - Phase 3+: one phase per user story, in priority order
-   - Final: Polish & cross-cutting
-   - Dependencies section + parallel execution examples per story
-   - Implementation strategy: MVP first
-
-5. **Report**: total count, count per story, parallel opportunities, MVP scope (usually US1), format validation (every task has checkbox + ID + labels + file path).
-
-6. Run `hooks.after_tasks` if present.
-
-## Checklist format (REQUIRED)
-
-```text
-- [ ] [TaskID] [P?] [Story?] Description with file path
-```
-
-- `- [ ]` — markdown checkbox, always
-- `T001, T002, …` — sequential task ID
-- `[P]` — include ONLY if parallelizable (different files, no blocking deps)
-- `[US1|US2|…]` — REQUIRED for story-phase tasks; OMIT for setup/foundational/polish
-- Description — action + exact file path
-
-Examples:
-- ✅ `- [ ] T001 Create project structure per plan`
-- ✅ `- [ ] T005 [P] Implement auth middleware in src/middleware/auth.py`
-- ✅ `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
-- ❌ `T001 [US1] Create model` (no checkbox)
-- ❌ `- [ ] T001 [US1] Create model` (no file path)
-
-## Rules
-
-- Tests are OPTIONAL — only generate test tasks if TDD is explicitly requested.
-- Each user story phase is independently testable (an MVP slice on its own).
-- Tasks hitting the same file are sequential, not `[P]`.
+3. Create dependency-ordered implementation tasks and store them in `<feature_directory>/tasks.md`.
+   - Every task uses checklist format: `- [ ] [TaskID] Description with file path`
+   - Organized by phase: setup, foundational, user stories in priority order, polish


### PR DESCRIPTION
## Summary

Syncs 6 spec-kit lean preset commands + 1 additional drifted command to match `fellowship-dev/spec-kit` HEAD (2026-05-25).

**Files updated in `.claude/commands/`:**
- `speckit.analyze.md` — updated to HEAD
- `speckit.constitution.md` — updated to HEAD
- `speckit.implement.md` — updated to HEAD
- `speckit.plan.md` — updated to HEAD
- `speckit.specify.md` — updated to HEAD
- `speckit.tasks.md` — updated to HEAD
- `speckit.checklist.md` — was uniquely drifted vs template; updated to `templates/commands/checklist.md` HEAD

**Files in sync (no change needed):**
- `speckit.clarify.md`, `speckit.taskstoissues.md`

## Source

Canonical source: `fellowship-dev/spec-kit` `presets/lean/commands/` and `templates/commands/`

🤖 Generated by tooling.cto spec-kit sync (2026-05-25)